### PR TITLE
Fix category field of product related events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- `category` field in `orderPlaced`, `productImpression`, `addToCart, and `removeFromCart`.
+- `category` field in `orderPlaced`, `productClick`, `productImpression`, `addToCart, and `removeFromCart`.
 
 ## [2.0.7] - 2019-07-23
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `category` field in `orderPlaced`, `productImpression`, `addToCart, and `removeFromCart`.
 
 ## [2.0.7] - 2019-07-23
 ### Added

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -92,6 +92,7 @@ export function handleEvents(e: PixelMessage) {
           add: {
             products: items.map((sku: any) => ({
               brand: sku.brand,
+              category: sku.category,
               id: sku.skuId,
               name: sku.name,
               price: `${sku.price}`,
@@ -115,6 +116,7 @@ export function handleEvents(e: PixelMessage) {
             products: items.map((sku: any) => ({
               brand: sku.brand,
               id: sku.skuId,
+              category: sku.category,
               name: sku.name,
               price: `${sku.price}`,
               quantity: sku.quantity,

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -214,12 +214,13 @@ function getCategory(rawCategories: string[]) {
     return
   }
 
-  const categories = rawCategories.map(function(categoryPath: string) {
-    const splitedPath = categoryPath.split('/').filter(Boolean)
-    return splitedPath[0]
-  })
+  return removeStartAndEndSlash(rawCategories[0])
+}
 
-  return categories ? categories[0] : categories
+// Transform this: "/Apparel & Accessories/Clothing/Tops/"
+// To this: "Apparel & Accessories/Clothing/Tops"
+function removeStartAndEndSlash(category: string) {
+  return category && category.replace(/^\/|\/$/g, '')
 }
 
 const getProductImpressionObjectData = (list: string) => ({

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -157,10 +157,12 @@ export function handleEvents(e: PixelMessage) {
         let oldImpresionFormat: Record<string, any> | null = null
         if (product != null && position != null) {
           // make it backwards compatible
-          oldImpresionFormat = [getProductImpressionObjectData(list)({
-            product,
-            position,
-          })]
+          oldImpresionFormat = [
+            getProductImpressionObjectData(list)({
+              product,
+              position,
+            }),
+          ]
         }
 
         const parsedImpressions = (impressions || []).map(

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -39,7 +39,7 @@ export function handleEvents(e: PixelMessage) {
             products: [
               {
                 brand,
-                category: category && category.replace(/^\/|\/$/g, ''),
+                category: removeStartAndEndSlash(category),
                 id: productId,
                 name: productName,
                 price,
@@ -129,7 +129,7 @@ export function handleEvents(e: PixelMessage) {
       return
     }
     case 'vtex:orderPlaced': {
-      const order = e.data as Order
+      const order = e.data
 
       const ecommerce = {
         purchase: {
@@ -200,7 +200,7 @@ function getPurchaseObjectData(order: Order) {
 function getProductObjectData(product: ProductOrder) {
   return {
     brand: product.brand,
-    category: product.category,
+    category: product.categoryTree && product.categoryTree.join('/'),
     id: product.sku,
     name: product.name,
     price: product.price,

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -24,8 +24,6 @@ export function handleEvents(e: PixelMessage) {
     case 'vtex:productView': {
       const { productId, productName, brand, categories } = e.data.product
 
-      const category = categories[0] as string
-
       let price
       try {
         price = e.data.product.items[0].sellers[0].commertialOffer.Price
@@ -39,7 +37,7 @@ export function handleEvents(e: PixelMessage) {
             products: [
               {
                 brand,
-                category: removeStartAndEndSlash(category),
+                category: getCategory(categories),
                 id: productId,
                 name: productName,
                 price,
@@ -54,9 +52,7 @@ export function handleEvents(e: PixelMessage) {
       return
     }
     case 'vtex:productClick': {
-      const { productId, productName, brand, categories, sku} = e.data.product
-
-      const category = categories[0] as string
+      const { productId, productName, brand, categories, sku } = e.data.product
 
       let price
       try {
@@ -69,16 +65,18 @@ export function handleEvents(e: PixelMessage) {
         event: 'productClick',
         ecommerce: {
           click: {
-            products: [{
-              name: productName,
-              id: productId,
-              price: price,
-              brand: brand,
-              category: category,
-              variant: sku.name,
-            }]
-          }
-        }
+            products: [
+              {
+                brand,
+                category: getCategory(categories),
+                id: productId,
+                name: productName,
+                variant: sku.name,
+                price,
+              },
+            ],
+          },
+        },
       }
 
       push(data)

--- a/react/typings/events.d.ts
+++ b/react/typings/events.d.ts
@@ -26,13 +26,13 @@ export interface PageViewData extends EventData {
 export interface AddToCartData extends EventData {
   event: 'addToCart'
   eventName: 'vtex:addToCart'
-  items: any[]
+  items: CartItem[]
 }
 
 export interface RemoveToCartData extends EventData {
   event: 'removeFromCart'
   eventName: 'vtex:removeFromCart'
-  items: any[]
+  items: CartItem[]
 }
 
 export interface OrderPlacedData extends Order, EventData {
@@ -59,6 +59,17 @@ export interface ProductImpressionData extends EventData {
   product?: Product // deprecated, use impressions list!
   position?: number // deprecated, use impressions list!
   list: string
+}
+
+interface CartItem {
+  skuId: string
+  variant: string
+  price: number
+  name: string
+  quantity: number
+  productRefId: string
+  brand: string
+  category: string
 }
 
 export interface Order {
@@ -112,6 +123,9 @@ interface ProductOrder {
   sku: string
   skuRefId: string
   skuName: string
+  productRefId: string
+  ean: string
+  slug: string
   brand: string
   brandId: string
   seller: string


### PR DESCRIPTION
#### What is the purpose of this pull request?

Events that had products in it would give the attribute `category` different formats. This PR makes all events related to products use the same semantics of the `category` field.

#### What problem is this solving?

In some events the field category of a product would come as:

> category: "Apparel & Accessories/Clothing/Tops"

While in others would come as:

> category: "Tops"

This PR makes removes the second way of attributing the category fields.

#### How should this be manually tested?

https://breno--storecomponents.myvtex.com/

#### Screenshots or example usage

Product Impression

![image](https://user-images.githubusercontent.com/284515/61737746-3b4e5b00-ad5f-11e9-87af-7f55b16fb02f.png)

Add to Cart

![image](https://user-images.githubusercontent.com/284515/61737779-4d2ffe00-ad5f-11e9-81de-bbb39582095a.png)

Remove from Cart

![image](https://user-images.githubusercontent.com/284515/61737801-57ea9300-ad5f-11e9-899d-c0be5a32b147.png)

Product Detail

![image](https://user-images.githubusercontent.com/284515/61737845-6df85380-ad5f-11e9-9526-79aa5558a7e3.png)

Order Placed

![image](https://user-images.githubusercontent.com/284515/61737967-ad26a480-ad5f-11e9-8f02-957f50eaabad.png)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
