### PR TITLE
Change events to send the id of the visible SKU

### DIFF
--- a/.vtexignore
+++ b/.vtexignore
@@ -14,3 +14,5 @@ react/__tests__/**
 react/.babelrc
 react/.eslintrc
 react/tests-setup.js
+react/__mocks__
+react/__tests__

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Change `productDetail` event to send `id` and `variant` of the visible SKU
+- Change `productClick` event to send `id` of the visible SKU
+- Change `productImpression` event to send `id` of the visible SKU
 
 ## [2.1.0] - 2019-08-30
 

--- a/react/__mocks__/productClick.ts
+++ b/react/__mocks__/productClick.ts
@@ -1,0 +1,249 @@
+import { ProductClickData } from '../typings/events'
+
+const productClick: ProductClickData = {
+  "currency": "USD",
+  "eventName": "vtex:productClick",
+  "event": "productClick",
+  "product": {
+    "cacheId": "classic-shoes",
+    "productId": "16",
+    "productName": "Classic Shoes Top",
+    "productReference": "12531",
+    "description": "If you go classic, you can't go wrong.",
+    "categories": [
+      "/Apparel & Accessories/Shoes/",
+      "/Apparel & Accessories/"
+    ],
+    "link": "https://portal.vtexcommercestable.com.br/classic-shoes/p",
+    "linkText": "classic-shoes",
+    "brand": "Mizuno",
+    "brandId": 2000010,
+    "items": [
+      {
+        "name": "Classic Pink",
+        "itemId": "35",
+        "measurementUnit": "un",
+        "unitMultiplier": 1,
+        "referenceId": [
+          {
+            "Value": "12531",
+            "__typename": "Reference"
+          }
+        ],
+        "images": [
+          {
+            "imageUrl": "https://storecomponents.vteximg.com.br/arquivos/ids/155470/Frame-11.jpg?v=636793763155730000",
+            "imageTag": "<img src=\"~/arquivos/ids/155470-#width#-#height#/Frame-11.jpg?v=636793763155730000\" width=\"#width#\" height=\"#height#\" alt=\"Frame-11\" id=\"\" />",
+            "imageLabel": "",
+            "__typename": "Image"
+          },
+          {
+            "imageUrl": "https://storecomponents.vteximg.com.br/arquivos/ids/155471/Frame-10.jpg?v=637018188181300000",
+            "imageTag": "<img src=\"~/arquivos/ids/155471-#width#-#height#/Frame-10.jpg?v=637018188181300000\" width=\"#width#\" height=\"#height#\" alt=\"Frame-10\" id=\"\" />",
+            "imageLabel": "",
+            "__typename": "Image"
+          }
+        ],
+        "sellers": [
+          {
+            "sellerId": "1",
+            "commertialOffer": {
+              "Installments": [
+                {
+                  "Value": 13,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 38.9,
+                  "NumberOfInstallments": 3,
+                  "Name": "Customer Credit 3 vezes sem juros",
+                  "__typename": "Installment"
+                }
+              ],
+              "AvailableQuantity": 2000000,
+              "Price": 38.9,
+              "ListPrice": 38.9,
+              "__typename": "Offer"
+            },
+            "__typename": "Seller"
+          }
+        ],
+        "__typename": "SKU"
+      },
+      {
+        "name": "White Slip On",
+        "itemId": "36",
+        "measurementUnit": "un",
+        "unitMultiplier": 1,
+        "referenceId": [
+          {
+            "Value": "12532",
+            "__typename": "Reference"
+          }
+        ],
+        "images": [
+          {
+            "imageUrl": "https://storecomponents.vteximg.com.br/arquivos/ids/155472/Frame-3.jpg?v=636793763985400000",
+            "imageTag": "<img src=\"~/arquivos/ids/155472-#width#-#height#/Frame-3.jpg?v=636793763985400000\" width=\"#width#\" height=\"#height#\" alt=\"Frame-3\" id=\"\" />",
+            "imageLabel": "",
+            "__typename": "Image"
+          },
+          {
+            "imageUrl": "https://storecomponents.vteximg.com.br/arquivos/ids/155473/Frame.jpg?v=636793764101900000",
+            "imageTag": "<img src=\"~/arquivos/ids/155473-#width#-#height#/Frame.jpg?v=636793764101900000\" width=\"#width#\" height=\"#height#\" alt=\"Frame\" id=\"\" />",
+            "imageLabel": "",
+            "__typename": "Image"
+          }
+        ],
+        "sellers": [
+          {
+            "sellerId": "1",
+            "commertialOffer": {
+              "Installments": [
+                {
+                  "Value": 43.8,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 262.5,
+                  "NumberOfInstallments": 6,
+                  "Name": "Mastercard 6 vezes sem juros",
+                  "__typename": "Installment"
+                }
+              ],
+              "AvailableQuantity": 2000000,
+              "Price": 262.5,
+              "ListPrice": 262.5,
+              "__typename": "Offer"
+            },
+            "__typename": "Seller"
+          }
+        ],
+        "__typename": "SKU"
+      },
+      {
+        "name": "Cool Pink",
+        "itemId": "37",
+        "measurementUnit": "un",
+        "unitMultiplier": 1,
+        "referenceId": [
+          {
+            "Value": "12533",
+            "__typename": "Reference"
+          }
+        ],
+        "images": [
+          {
+            "imageUrl": "https://storecomponents.vteximg.com.br/arquivos/ids/155474/Frame-1.jpg?v=636793764631500000",
+            "imageTag": "<img src=\"~/arquivos/ids/155474-#width#-#height#/Frame-1.jpg?v=636793764631500000\" width=\"#width#\" height=\"#height#\" alt=\"Frame-1\" id=\"\" />",
+            "imageLabel": "",
+            "__typename": "Image"
+          },
+          {
+            "imageUrl": "https://storecomponents.vteximg.com.br/arquivos/ids/155475/Frame-2.jpg?v=636793764763600000",
+            "imageTag": "<img src=\"~/arquivos/ids/155475-#width#-#height#/Frame-2.jpg?v=636793764763600000\" width=\"#width#\" height=\"#height#\" alt=\"Frame-2\" id=\"\" />",
+            "imageLabel": "",
+            "__typename": "Image"
+          }
+        ],
+        "sellers": [
+          {
+            "sellerId": "1",
+            "commertialOffer": {
+              "Installments": [
+                {
+                  "Value": 3.5,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 10.5,
+                  "NumberOfInstallments": 3,
+                  "Name": "Customer Credit 3 vezes sem juros",
+                  "__typename": "Installment"
+                }
+              ],
+              "AvailableQuantity": 1000000,
+              "Price": 10.5,
+              "ListPrice": 10.5,
+              "__typename": "Offer"
+            },
+            "__typename": "Seller"
+          }
+        ],
+        "__typename": "SKU"
+      }
+    ],
+    "productClusters": [],
+    "properties": [],
+    "__typename": "Product",
+    "sku": {
+      "name": "Classic Pink",
+      "itemId": "35",
+      "measurementUnit": "un",
+      "unitMultiplier": 1,
+      "referenceId": {
+        "Value": "12531",
+        "__typename": "Reference"
+      },
+      "images": [
+        {
+          "imageUrl": "https://storecomponents.vteximg.com.br/arquivos/ids/155470-500-auto?width=500&height=auto&aspect=true",
+          "imageTag": "<img src=\"~/arquivos/ids/155470-#width#-#height#/Frame-11.jpg?v=636793763155730000\" width=\"#width#\" height=\"#height#\" alt=\"Frame-11\" id=\"\" />",
+          "imageLabel": "",
+          "__typename": "Image"
+        },
+        {
+          "imageUrl": "https://storecomponents.vteximg.com.br/arquivos/ids/155471-500-auto?width=500&height=auto&aspect=true",
+          "imageTag": "<img src=\"~/arquivos/ids/155471-#width#-#height#/Frame-10.jpg?v=637018188181300000\" width=\"#width#\" height=\"#height#\" alt=\"Frame-10\" id=\"\" />",
+          "imageLabel": "",
+          "__typename": "Image"
+        }
+      ],
+      "sellers": [
+        {
+          "sellerId": "1",
+          "commertialOffer": {
+            "Installments": [
+              {
+                "Value": 13,
+                "InterestRate": 0,
+                "TotalValuePlusInterestRate": 38.9,
+                "NumberOfInstallments": 3,
+                "Name": "Customer Credit 3 vezes sem juros",
+                "__typename": "Installment"
+              }
+            ],
+            "AvailableQuantity": 2000000,
+            "Price": 38.9,
+            "ListPrice": 38.9,
+            "__typename": "Offer"
+          },
+          "__typename": "Seller"
+        }
+      ],
+      "__typename": "SKU",
+      "seller": {
+        "sellerId": "1",
+        "commertialOffer": {
+          "Installments": [
+            {
+              "Value": 13,
+              "InterestRate": 0,
+              "TotalValuePlusInterestRate": 38.9,
+              "NumberOfInstallments": 3,
+              "Name": "Customer Credit 3 vezes sem juros",
+              "__typename": "Installment"
+            }
+          ],
+          "AvailableQuantity": 2000000,
+          "Price": 38.9,
+          "ListPrice": 38.9,
+          "__typename": "Offer"
+        },
+        "__typename": "Seller"
+      },
+      "image": {
+        "imageUrl": "https://storecomponents.vteximg.com.br/arquivos/ids/155470-500-auto?width=500&height=auto&aspect=true",
+        "imageTag": "<img src=\"~/arquivos/ids/155470-#width#-#height#/Frame-11.jpg?v=636793763155730000\" width=\"#width#\" height=\"#height#\" alt=\"Frame-11\" id=\"\" />",
+        "imageLabel": "",
+        "__typename": "Image"
+      }
+    }
+  }
+}
+
+export default productClick

--- a/react/__mocks__/productDetail.ts
+++ b/react/__mocks__/productDetail.ts
@@ -1,0 +1,793 @@
+import { ProductViewData } from '../typings/events'
+
+const productDetail: ProductViewData = {
+  "currency": "USD",
+  "eventName": "vtex:productView",
+  "event": "productView",
+  "product": {
+    "cacheId": "classic-shoes",
+    "productName": "Classic Shoes Top",
+    "productId": "16",
+    "description": "If you go classic, you can't go wrong.",
+    "titleTag": "Classic Shoes",
+    "metaTagDescription": "If you go classic, you can't go wrong.",
+    "linkText": "classic-shoes",
+    "productReference": "12531",
+    "categories": [
+      "/Apparel & Accessories/Shoes/",
+      "/Apparel & Accessories/"
+    ],
+    "categoryId": "10",
+    "categoriesIds": [
+      "/25/10/",
+      "/25/"
+    ],
+    "brand": "Mizuno",
+    "brandId": 2000010,
+    "properties": [],
+    "specificationGroups": [
+      {
+        "name": "allSpecifications",
+        "specifications": [],
+        "__typename": "SpecificationGroup"
+      }
+    ],
+    "items": [
+      {
+        "itemId": "35",
+        "name": "Classic Pink",
+        "nameComplete": "Classic Shoes Top Classic Pink",
+        "complementName": "Os corredores de alta performance terão um grande aliado com o Tênis Mizuno Wave Viper 3 Masculino. A placa Wave de ponta a ponta garante um amortecimento responsivo do começo ao fim da corrida.",
+        "ean": "80098",
+        "referenceId": [
+          {
+            "Key": "RefId",
+            "Value": "12531",
+            "__typename": "Reference"
+          }
+        ],
+        "measurementUnit": "un",
+        "unitMultiplier": 1,
+        "images": [
+          {
+            "imageId": "155470",
+            "imageLabel": "",
+            "imageTag": "<img src=\"~/arquivos/ids/155470-#width#-#height#/Frame-11.jpg?v=636793763155730000\" width=\"#width#\" height=\"#height#\" alt=\"Frame-11\" id=\"\" />",
+            "imageUrl": "https://storecomponents.vteximg.com.br/arquivos/ids/155470/Frame-11.jpg?v=636793763155730000",
+            "imageText": "Frame-11",
+            "__typename": "Image"
+          },
+          {
+            "imageId": "155471",
+            "imageLabel": "",
+            "imageTag": "<img src=\"~/arquivos/ids/155471-#width#-#height#/Frame-10.jpg?v=637018188181300000\" width=\"#width#\" height=\"#height#\" alt=\"Frame-10\" id=\"\" />",
+            "imageUrl": "https://storecomponents.vteximg.com.br/arquivos/ids/155471/Frame-10.jpg?v=637018188181300000",
+            "imageText": "Frame-10",
+            "__typename": "Image"
+          }
+        ],
+        "videos": [],
+        "sellers": [
+          {
+            "sellerId": "1",
+            "sellerName": "VTEX",
+            "addToCartLink": "https://portal.vtexcommercestable.com.br/checkout/cart/add?sku=35&qty=1&seller=1&sc=1&price=3890&cv=d1d26b494a83cac2e7812d2818e8ed1e_&sc=1",
+            "sellerDefault": true,
+            "commertialOffer": {
+              "discountHighlights": [],
+              "teasers": [],
+              "Price": 38.9,
+              "ListPrice": 38.9,
+              "PriceWithoutDiscount": 38.9,
+              "RewardValue": 0,
+              "PriceValidUntil": "2020-09-05T22:07:59.9154441Z",
+              "AvailableQuantity": 2000000,
+              "Tax": 0,
+              "CacheVersionUsedToCallCheckout": "d1d26b494a83cac2e7812d2818e8ed1e_",
+              "Installments": [
+                {
+                  "Value": 38.9,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 38.9,
+                  "NumberOfInstallments": 1,
+                  "Name": "American Express à vista",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 38.9,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 38.9,
+                  "NumberOfInstallments": 1,
+                  "Name": "Visa à vista",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 19.5,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 38.9,
+                  "NumberOfInstallments": 2,
+                  "Name": "Visa 2 vezes sem juros",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 13,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 38.9,
+                  "NumberOfInstallments": 3,
+                  "Name": "Visa 3 vezes sem juros",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 38.9,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 38.9,
+                  "NumberOfInstallments": 1,
+                  "Name": "Mastercard à vista",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 19.5,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 38.9,
+                  "NumberOfInstallments": 2,
+                  "Name": "Mastercard 2 vezes sem juros",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 13,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 38.9,
+                  "NumberOfInstallments": 3,
+                  "Name": "Mastercard 3 vezes sem juros",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 38.9,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 38.9,
+                  "NumberOfInstallments": 1,
+                  "Name": "Boleto Bancário à vista",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 38.9,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 38.9,
+                  "NumberOfInstallments": 1,
+                  "Name": "Promissory à vista",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 38.9,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 38.9,
+                  "NumberOfInstallments": 1,
+                  "Name": "Customer Credit à vista",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 19.5,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 38.9,
+                  "NumberOfInstallments": 2,
+                  "Name": "Customer Credit 2 vezes sem juros",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 13,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 38.9,
+                  "NumberOfInstallments": 3,
+                  "Name": "Customer Credit 3 vezes sem juros",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 38.9,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 38.9,
+                  "NumberOfInstallments": 1,
+                  "Name": "Free à vista",
+                  "__typename": "Installment"
+                }
+              ],
+              "__typename": "Offer"
+            },
+            "__typename": "Seller"
+          }
+        ],
+        "variations": [
+          {
+            "name": "Tamanho",
+            "values": [
+              "40"
+            ],
+            "__typename": "Property"
+          },
+          {
+            "name": "Cor",
+            "values": [
+              "Verde"
+            ],
+            "__typename": "Property"
+          }
+        ],
+        "kitItems": [],
+        "attachments": [],
+        "calculatedAttachments": null,
+        "__typename": "SKU"
+      },
+      {
+        "itemId": "36",
+        "name": "White Slip On",
+        "nameComplete": "Classic Shoes Top White Slip On",
+        "complementName": "Os corredores de alta performance terão um grande aliado com o Tênis Mizuno Wave Viper 3 Masculino. A placa Wave de ponta a ponta garante um amortecimento responsivo do começo ao fim da corrida.",
+        "ean": "80099",
+        "referenceId": [
+          {
+            "Key": "RefId",
+            "Value": "12532",
+            "__typename": "Reference"
+          }
+        ],
+        "measurementUnit": "un",
+        "unitMultiplier": 1,
+        "images": [
+          {
+            "imageId": "155472",
+            "imageLabel": "",
+            "imageTag": "<img src=\"~/arquivos/ids/155472-#width#-#height#/Frame-3.jpg?v=636793763985400000\" width=\"#width#\" height=\"#height#\" alt=\"Frame-3\" id=\"\" />",
+            "imageUrl": "https://storecomponents.vteximg.com.br/arquivos/ids/155472/Frame-3.jpg?v=636793763985400000",
+            "imageText": "Frame-3",
+            "__typename": "Image"
+          },
+          {
+            "imageId": "155473",
+            "imageLabel": "",
+            "imageTag": "<img src=\"~/arquivos/ids/155473-#width#-#height#/Frame.jpg?v=636793764101900000\" width=\"#width#\" height=\"#height#\" alt=\"Frame\" id=\"\" />",
+            "imageUrl": "https://storecomponents.vteximg.com.br/arquivos/ids/155473/Frame.jpg?v=636793764101900000",
+            "imageText": "Frame",
+            "__typename": "Image"
+          }
+        ],
+        "videos": [],
+        "sellers": [
+          {
+            "sellerId": "1",
+            "sellerName": "VTEX",
+            "addToCartLink": "https://portal.vtexcommercestable.com.br/checkout/cart/add?sku=36&qty=1&seller=1&sc=1&price=26250&cv=d1d26b494a83cac2e7812d2818e8ed1e_&sc=1",
+            "sellerDefault": true,
+            "commertialOffer": {
+              "discountHighlights": [],
+              "teasers": [],
+              "Price": 262.5,
+              "ListPrice": 262.5,
+              "PriceWithoutDiscount": 262.5,
+              "RewardValue": 0,
+              "PriceValidUntil": "2020-09-05T22:08:00.0271609Z",
+              "AvailableQuantity": 2000000,
+              "Tax": 0,
+              "CacheVersionUsedToCallCheckout": "d1d26b494a83cac2e7812d2818e8ed1e_",
+              "Installments": [
+                {
+                  "Value": 262.5,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 262.5,
+                  "NumberOfInstallments": 1,
+                  "Name": "American Express à vista",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 262.5,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 262.5,
+                  "NumberOfInstallments": 1,
+                  "Name": "Visa à vista",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 131.3,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 262.5,
+                  "NumberOfInstallments": 2,
+                  "Name": "Visa 2 vezes sem juros",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 87.5,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 262.5,
+                  "NumberOfInstallments": 3,
+                  "Name": "Visa 3 vezes sem juros",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 65.7,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 262.5,
+                  "NumberOfInstallments": 4,
+                  "Name": "Visa 4 vezes sem juros",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 52.5,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 262.5,
+                  "NumberOfInstallments": 5,
+                  "Name": "Visa 5 vezes sem juros",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 43.8,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 262.5,
+                  "NumberOfInstallments": 6,
+                  "Name": "Visa 6 vezes sem juros",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 262.5,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 262.5,
+                  "NumberOfInstallments": 1,
+                  "Name": "Mastercard à vista",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 131.3,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 262.5,
+                  "NumberOfInstallments": 2,
+                  "Name": "Mastercard 2 vezes sem juros",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 87.5,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 262.5,
+                  "NumberOfInstallments": 3,
+                  "Name": "Mastercard 3 vezes sem juros",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 65.7,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 262.5,
+                  "NumberOfInstallments": 4,
+                  "Name": "Mastercard 4 vezes sem juros",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 52.5,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 262.5,
+                  "NumberOfInstallments": 5,
+                  "Name": "Mastercard 5 vezes sem juros",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 43.8,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 262.5,
+                  "NumberOfInstallments": 6,
+                  "Name": "Mastercard 6 vezes sem juros",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 262.5,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 262.5,
+                  "NumberOfInstallments": 1,
+                  "Name": "Boleto Bancário à vista",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 262.5,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 262.5,
+                  "NumberOfInstallments": 1,
+                  "Name": "Promissory à vista",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 262.5,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 262.5,
+                  "NumberOfInstallments": 1,
+                  "Name": "Customer Credit à vista",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 131.3,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 262.5,
+                  "NumberOfInstallments": 2,
+                  "Name": "Customer Credit 2 vezes sem juros",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 87.5,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 262.5,
+                  "NumberOfInstallments": 3,
+                  "Name": "Customer Credit 3 vezes sem juros",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 262.5,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 262.5,
+                  "NumberOfInstallments": 1,
+                  "Name": "Free à vista",
+                  "__typename": "Installment"
+                }
+              ],
+              "__typename": "Offer"
+            },
+            "__typename": "Seller"
+          }
+        ],
+        "variations": [
+          {
+            "name": "Tamanho",
+            "values": [
+              "41"
+            ],
+            "__typename": "Property"
+          },
+          {
+            "name": "Cor",
+            "values": [
+              "Cinza"
+            ],
+            "__typename": "Property"
+          }
+        ],
+        "kitItems": [],
+        "attachments": [],
+        "calculatedAttachments": null,
+        "__typename": "SKU"
+      },
+      {
+        "itemId": "37",
+        "name": "Cool Pink",
+        "nameComplete": "Classic Shoes Top Cool Pink",
+        "complementName": "Os corredores de alta performance terão um grande aliado com o Tênis Mizuno Wave Viper 3 Masculino. A placa Wave de ponta a ponta garante um amortecimento responsivo do começo ao fim da corrida.",
+        "ean": "80100",
+        "referenceId": [
+          {
+            "Key": "RefId",
+            "Value": "12533",
+            "__typename": "Reference"
+          }
+        ],
+        "measurementUnit": "un",
+        "unitMultiplier": 1,
+        "images": [
+          {
+            "imageId": "155474",
+            "imageLabel": "",
+            "imageTag": "<img src=\"~/arquivos/ids/155474-#width#-#height#/Frame-1.jpg?v=636793764631500000\" width=\"#width#\" height=\"#height#\" alt=\"Frame-1\" id=\"\" />",
+            "imageUrl": "https://storecomponents.vteximg.com.br/arquivos/ids/155474/Frame-1.jpg?v=636793764631500000",
+            "imageText": "Frame-1",
+            "__typename": "Image"
+          },
+          {
+            "imageId": "155475",
+            "imageLabel": "",
+            "imageTag": "<img src=\"~/arquivos/ids/155475-#width#-#height#/Frame-2.jpg?v=636793764763600000\" width=\"#width#\" height=\"#height#\" alt=\"Frame-2\" id=\"\" />",
+            "imageUrl": "https://storecomponents.vteximg.com.br/arquivos/ids/155475/Frame-2.jpg?v=636793764763600000",
+            "imageText": "Frame-2",
+            "__typename": "Image"
+          }
+        ],
+        "videos": [],
+        "sellers": [
+          {
+            "sellerId": "1",
+            "sellerName": "VTEX",
+            "addToCartLink": "https://portal.vtexcommercestable.com.br/checkout/cart/add?sku=37&qty=1&seller=1&sc=1&price=1050&cv=d1d26b494a83cac2e7812d2818e8ed1e_&sc=1",
+            "sellerDefault": true,
+            "commertialOffer": {
+              "discountHighlights": [],
+              "teasers": [],
+              "Price": 10.5,
+              "ListPrice": 10.5,
+              "PriceWithoutDiscount": 10.5,
+              "RewardValue": 0,
+              "PriceValidUntil": "2020-09-05T22:07:59.9387089Z",
+              "AvailableQuantity": 1000000,
+              "Tax": 0,
+              "CacheVersionUsedToCallCheckout": "d1d26b494a83cac2e7812d2818e8ed1e_",
+              "Installments": [
+                {
+                  "Value": 10.5,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 10.5,
+                  "NumberOfInstallments": 1,
+                  "Name": "American Express à vista",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 10.5,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 10.5,
+                  "NumberOfInstallments": 1,
+                  "Name": "Visa à vista",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 10.5,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 10.5,
+                  "NumberOfInstallments": 1,
+                  "Name": "Mastercard à vista",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 10.5,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 10.5,
+                  "NumberOfInstallments": 1,
+                  "Name": "Boleto Bancário à vista",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 10.5,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 10.5,
+                  "NumberOfInstallments": 1,
+                  "Name": "Promissory à vista",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 10.5,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 10.5,
+                  "NumberOfInstallments": 1,
+                  "Name": "Customer Credit à vista",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 5.3,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 10.5,
+                  "NumberOfInstallments": 2,
+                  "Name": "Customer Credit 2 vezes sem juros",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 3.5,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 10.5,
+                  "NumberOfInstallments": 3,
+                  "Name": "Customer Credit 3 vezes sem juros",
+                  "__typename": "Installment"
+                },
+                {
+                  "Value": 10.5,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 10.5,
+                  "NumberOfInstallments": 1,
+                  "Name": "Free à vista",
+                  "__typename": "Installment"
+                }
+              ],
+              "__typename": "Offer"
+            },
+            "__typename": "Seller"
+          }
+        ],
+        "variations": [
+          {
+            "name": "Tamanho",
+            "values": [
+              "42"
+            ],
+            "__typename": "Property"
+          },
+          {
+            "name": "Cor",
+            "values": [
+              "Preto"
+            ],
+            "__typename": "Property"
+          }
+        ],
+        "kitItems": [],
+        "attachments": [],
+        "calculatedAttachments": null,
+        "__typename": "SKU"
+      }
+    ],
+    "itemMetadata": null,
+    "productClusters": [],
+    "clusterHighlights": [],
+    "__typename": "Product",
+    "benefits": [],
+    "selectedSku": {
+      "itemId": "35",
+      "name": "Classic Pink",
+      "nameComplete": "Classic Shoes Top Classic Pink",
+      "complementName": "Os corredores de alta performance terão um grande aliado com o Tênis Mizuno Wave Viper 3 Masculino. A placa Wave de ponta a ponta garante um amortecimento responsivo do começo ao fim da corrida.",
+      "ean": "80098",
+      "referenceId": [
+        {
+          "Key": "RefId",
+          "Value": "12531",
+          "__typename": "Reference"
+        }
+      ],
+      "measurementUnit": "un",
+      "unitMultiplier": 1,
+      "images": [
+        {
+          "imageId": "155470",
+          "imageLabel": "",
+          "imageTag": "<img src=\"~/arquivos/ids/155470-#width#-#height#/Frame-11.jpg?v=636793763155730000\" width=\"#width#\" height=\"#height#\" alt=\"Frame-11\" id=\"\" />",
+          "imageUrl": "https://storecomponents.vteximg.com.br/arquivos/ids/155470/Frame-11.jpg?v=636793763155730000",
+          "imageText": "Frame-11",
+          "__typename": "Image"
+        },
+        {
+          "imageId": "155471",
+          "imageLabel": "",
+          "imageTag": "<img src=\"~/arquivos/ids/155471-#width#-#height#/Frame-10.jpg?v=637018188181300000\" width=\"#width#\" height=\"#height#\" alt=\"Frame-10\" id=\"\" />",
+          "imageUrl": "https://storecomponents.vteximg.com.br/arquivos/ids/155471/Frame-10.jpg?v=637018188181300000",
+          "imageText": "Frame-10",
+          "__typename": "Image"
+        }
+      ],
+      "videos": [],
+      "sellers": [
+        {
+          "sellerId": "1",
+          "sellerName": "VTEX",
+          "addToCartLink": "https://portal.vtexcommercestable.com.br/checkout/cart/add?sku=35&qty=1&seller=1&sc=1&price=3890&cv=d1d26b494a83cac2e7812d2818e8ed1e_&sc=1",
+          "sellerDefault": true,
+          "commertialOffer": {
+            "discountHighlights": [],
+            "teasers": [],
+            "Price": 38.9,
+            "ListPrice": 38.9,
+            "PriceWithoutDiscount": 38.9,
+            "RewardValue": 0,
+            "PriceValidUntil": "2020-09-05T22:07:59.9154441Z",
+            "AvailableQuantity": 2000000,
+            "Tax": 0,
+            "CacheVersionUsedToCallCheckout": "d1d26b494a83cac2e7812d2818e8ed1e_",
+            "Installments": [
+              {
+                "Value": 38.9,
+                "InterestRate": 0,
+                "TotalValuePlusInterestRate": 38.9,
+                "NumberOfInstallments": 1,
+                "Name": "American Express à vista",
+                "__typename": "Installment"
+              },
+              {
+                "Value": 38.9,
+                "InterestRate": 0,
+                "TotalValuePlusInterestRate": 38.9,
+                "NumberOfInstallments": 1,
+                "Name": "Visa à vista",
+                "__typename": "Installment"
+              },
+              {
+                "Value": 19.5,
+                "InterestRate": 0,
+                "TotalValuePlusInterestRate": 38.9,
+                "NumberOfInstallments": 2,
+                "Name": "Visa 2 vezes sem juros",
+                "__typename": "Installment"
+              },
+              {
+                "Value": 13,
+                "InterestRate": 0,
+                "TotalValuePlusInterestRate": 38.9,
+                "NumberOfInstallments": 3,
+                "Name": "Visa 3 vezes sem juros",
+                "__typename": "Installment"
+              },
+              {
+                "Value": 38.9,
+                "InterestRate": 0,
+                "TotalValuePlusInterestRate": 38.9,
+                "NumberOfInstallments": 1,
+                "Name": "Mastercard à vista",
+                "__typename": "Installment"
+              },
+              {
+                "Value": 19.5,
+                "InterestRate": 0,
+                "TotalValuePlusInterestRate": 38.9,
+                "NumberOfInstallments": 2,
+                "Name": "Mastercard 2 vezes sem juros",
+                "__typename": "Installment"
+              },
+              {
+                "Value": 13,
+                "InterestRate": 0,
+                "TotalValuePlusInterestRate": 38.9,
+                "NumberOfInstallments": 3,
+                "Name": "Mastercard 3 vezes sem juros",
+                "__typename": "Installment"
+              },
+              {
+                "Value": 38.9,
+                "InterestRate": 0,
+                "TotalValuePlusInterestRate": 38.9,
+                "NumberOfInstallments": 1,
+                "Name": "Boleto Bancário à vista",
+                "__typename": "Installment"
+              },
+              {
+                "Value": 38.9,
+                "InterestRate": 0,
+                "TotalValuePlusInterestRate": 38.9,
+                "NumberOfInstallments": 1,
+                "Name": "Promissory à vista",
+                "__typename": "Installment"
+              },
+              {
+                "Value": 38.9,
+                "InterestRate": 0,
+                "TotalValuePlusInterestRate": 38.9,
+                "NumberOfInstallments": 1,
+                "Name": "Customer Credit à vista",
+                "__typename": "Installment"
+              },
+              {
+                "Value": 19.5,
+                "InterestRate": 0,
+                "TotalValuePlusInterestRate": 38.9,
+                "NumberOfInstallments": 2,
+                "Name": "Customer Credit 2 vezes sem juros",
+                "__typename": "Installment"
+              },
+              {
+                "Value": 13,
+                "InterestRate": 0,
+                "TotalValuePlusInterestRate": 38.9,
+                "NumberOfInstallments": 3,
+                "Name": "Customer Credit 3 vezes sem juros",
+                "__typename": "Installment"
+              },
+              {
+                "Value": 38.9,
+                "InterestRate": 0,
+                "TotalValuePlusInterestRate": 38.9,
+                "NumberOfInstallments": 1,
+                "Name": "Free à vista",
+                "__typename": "Installment"
+              }
+            ],
+            "__typename": "Offer"
+          },
+          "__typename": "Seller"
+        }
+      ],
+      "variations": [
+        {
+          "name": "Tamanho",
+          "values": [
+            "40"
+          ],
+          "__typename": "Property"
+        },
+        {
+          "name": "Cor",
+          "values": [
+            "Verde"
+          ],
+          "__typename": "Property"
+        }
+      ],
+      "kitItems": [],
+      "attachments": [],
+      "calculatedAttachments": null,
+      "__typename": "SKU"
+    }
+  }
+}
+
+export default productDetail

--- a/react/__mocks__/productImpression.ts
+++ b/react/__mocks__/productImpression.ts
@@ -2,679 +2,388 @@
 import { ProductImpressionData } from '../typings/events'
 
 const productImpression: ProductImpressionData = {
-  currency: 'USD',
-  eventName: 'vtex:productImpression',
-  event: 'productImpression',
-  list: 'Shelf',
-  impressions: [
+  "currency": "USD",
+  "eventName": "vtex:productImpression",
+  "event": "productImpression",
+  "list": "Shelf",
+  "impressions": [
     {
-      position: 3,
-      product: {
-        cacheId: 'long-sleeve-shirt',
-        productId: '2000005',
-        productName: 'Long Sleeve Shirt - Regular',
-        description:
-          'Everything looks good on this trendy color. Even long sleeve shirts.',
-        categories: ['/Clothing/Shirts/', '/Clothing/'],
-        categoryTree: [
-          {
-            name: 'Clothing',
-            href: '/clothing/d',
-            __typename: 'vtex_storegraphql_2_76_0_Category',
-          },
-          {
-            name: 'Shirts',
-            href: '/clothing/shirts',
-            __typename: 'vtex_storegraphql_2_76_0_Category',
-          },
+      "product": {
+        "cacheId": "classic-shoes",
+        "productId": "16",
+        "productName": "Classic Shoes Top",
+        "productReference": "12531",
+        "description": "If you go classic, you can't go wrong.",
+        "categories": [
+          "/Apparel & Accessories/Shoes/",
+          "/Apparel & Accessories/"
         ],
-        link: 'https://portal.vtexcommercestable.com.br/long-sleeve-shirt/p',
-        linkText: 'long-sleeve-shirt',
-        brand: 'Apple',
-        items: [
+        "link": "https://portal.vtexcommercestable.com.br/classic-shoes/p",
+        "linkText": "classic-shoes",
+        "brand": "Mizuno",
+        "brandId": 2000010,
+        "items": [
           {
-            name: 'Regular',
-            itemId: '2000539',
-            referenceId: [
+            "name": "Classic Pink",
+            "itemId": "35",
+            "measurementUnit": "un",
+            "unitMultiplier": 1,
+            "referenceId": [
               {
-                Value: '98123719',
-                __typename: 'vtex_storegraphql_2_76_0_Reference',
-              },
+                "Value": "12531",
+                "__typename": "Reference"
+              }
             ],
-            images: [
+            "images": [
               {
-                imageUrl:
-                  'https://storecomponents.vteximg.com.br/arquivos/ids/155487/Frame-7.jpg?v=636793837686400000',
-                imageTag:
-                  '<img src="~/arquivos/ids/155487-#width#-#height#/Frame-7.jpg?v=636793837686400000" width="#width#" height="#height#" alt="Frame-7" id="" />',
-                __typename: 'vtex_storegraphql_2_76_0_Image',
+                "imageUrl": "https://storecomponents.vteximg.com.br/arquivos/ids/155470/Frame-11.jpg?v=636793763155730000",
+                "imageTag": "<img src=\"~/arquivos/ids/155470-#width#-#height#/Frame-11.jpg?v=636793763155730000\" width=\"#width#\" height=\"#height#\" alt=\"Frame-11\" id=\"\" />",
+                "imageLabel": "",
+                "__typename": "Image"
               },
-            ],
-            sellers: [
               {
-                sellerId: '1',
-                commertialOffer: {
-                  Installments: [
+                "imageUrl": "https://storecomponents.vteximg.com.br/arquivos/ids/155471/Frame-10.jpg?v=637018188181300000",
+                "imageTag": "<img src=\"~/arquivos/ids/155471-#width#-#height#/Frame-10.jpg?v=637018188181300000\" width=\"#width#\" height=\"#height#\" alt=\"Frame-10\" id=\"\" />",
+                "imageLabel": "",
+                "__typename": "Image"
+              }
+            ],
+            "sellers": [
+              {
+                "sellerId": "1",
+                "commertialOffer": {
+                  "Installments": [
                     {
-                      Value: 9450,
-                      InterestRate: 0,
-                      TotalValuePlusInterestRate: 9450,
-                      NumberOfInstallments: 1,
-                      Name: 'American Express à vista',
-                      __typename: 'vtex_storegraphql_2_76_0_Installment',
-                    },
-                    {
-                      Value: 9450,
-                      InterestRate: 0,
-                      TotalValuePlusInterestRate: 9450,
-                      NumberOfInstallments: 1,
-                      Name: 'Visa à vista',
-                      __typename: 'vtex_storegraphql_2_76_0_Installment',
-                    },
-                    {
-                      Value: 4725,
-                      InterestRate: 0,
-                      TotalValuePlusInterestRate: 9450,
-                      NumberOfInstallments: 2,
-                      Name: 'Visa 2 vezes sem juros',
-                      __typename: 'vtex_storegraphql_2_76_0_Installment',
-                    },
-                    {
-                      Value: 3150,
-                      InterestRate: 0,
-                      TotalValuePlusInterestRate: 9450,
-                      NumberOfInstallments: 3,
-                      Name: 'Visa 3 vezes sem juros',
-                      __typename: 'vtex_storegraphql_2_76_0_Installment',
-                    },
-                    {
-                      Value: 2362.5,
-                      InterestRate: 0,
-                      TotalValuePlusInterestRate: 9450,
-                      NumberOfInstallments: 4,
-                      Name: 'Visa 4 vezes sem juros',
-                      __typename: 'vtex_storegraphql_2_76_0_Installment',
-                    },
-                    {
-                      Value: 1890,
-                      InterestRate: 0,
-                      TotalValuePlusInterestRate: 9450,
-                      NumberOfInstallments: 5,
-                      Name: 'Visa 5 vezes sem juros',
-                      __typename: 'vtex_storegraphql_2_76_0_Installment',
-                    },
-                    {
-                      Value: 1575,
-                      InterestRate: 0,
-                      TotalValuePlusInterestRate: 9450,
-                      NumberOfInstallments: 6,
-                      Name: 'Visa 6 vezes sem juros',
-                      __typename: 'vtex_storegraphql_2_76_0_Installment',
-                    },
-                    {
-                      Value: 9450,
-                      InterestRate: 0,
-                      TotalValuePlusInterestRate: 9450,
-                      NumberOfInstallments: 1,
-                      Name: 'Mastercard à vista',
-                      __typename: 'vtex_storegraphql_2_76_0_Installment',
-                    },
-                    {
-                      Value: 4725,
-                      InterestRate: 0,
-                      TotalValuePlusInterestRate: 9450,
-                      NumberOfInstallments: 2,
-                      Name: 'Mastercard 2 vezes sem juros',
-                      __typename: 'vtex_storegraphql_2_76_0_Installment',
-                    },
-                    {
-                      Value: 3150,
-                      InterestRate: 0,
-                      TotalValuePlusInterestRate: 9450,
-                      NumberOfInstallments: 3,
-                      Name: 'Mastercard 3 vezes sem juros',
-                      __typename: 'vtex_storegraphql_2_76_0_Installment',
-                    },
-                    {
-                      Value: 2362.5,
-                      InterestRate: 0,
-                      TotalValuePlusInterestRate: 9450,
-                      NumberOfInstallments: 4,
-                      Name: 'Mastercard 4 vezes sem juros',
-                      __typename: 'vtex_storegraphql_2_76_0_Installment',
-                    },
-                    {
-                      Value: 1890,
-                      InterestRate: 0,
-                      TotalValuePlusInterestRate: 9450,
-                      NumberOfInstallments: 5,
-                      Name: 'Mastercard 5 vezes sem juros',
-                      __typename: 'vtex_storegraphql_2_76_0_Installment',
-                    },
-                    {
-                      Value: 1575,
-                      InterestRate: 0,
-                      TotalValuePlusInterestRate: 9450,
-                      NumberOfInstallments: 6,
-                      Name: 'Mastercard 6 vezes sem juros',
-                      __typename: 'vtex_storegraphql_2_76_0_Installment',
-                    },
-                    {
-                      Value: 9450,
-                      InterestRate: 0,
-                      TotalValuePlusInterestRate: 9450,
-                      NumberOfInstallments: 1,
-                      Name: 'Boleto Bancário à vista',
-                      __typename: 'vtex_storegraphql_2_76_0_Installment',
-                    },
-                    {
-                      Value: 9450,
-                      InterestRate: 0,
-                      TotalValuePlusInterestRate: 9450,
-                      NumberOfInstallments: 1,
-                      Name: 'Promissory à vista',
-                      __typename: 'vtex_storegraphql_2_76_0_Installment',
-                    },
-                    {
-                      Value: 9450,
-                      InterestRate: 0,
-                      TotalValuePlusInterestRate: 9450,
-                      NumberOfInstallments: 1,
-                      Name: 'Customer Credit à vista',
-                      __typename: 'vtex_storegraphql_2_76_0_Installment',
-                    },
-                    {
-                      Value: 4725,
-                      InterestRate: 0,
-                      TotalValuePlusInterestRate: 9450,
-                      NumberOfInstallments: 2,
-                      Name: 'Customer Credit 2 vezes sem juros',
-                      __typename: 'vtex_storegraphql_2_76_0_Installment',
-                    },
-                    {
-                      Value: 3150,
-                      InterestRate: 0,
-                      TotalValuePlusInterestRate: 9450,
-                      NumberOfInstallments: 3,
-                      Name: 'Customer Credit 3 vezes sem juros',
-                      __typename: 'vtex_storegraphql_2_76_0_Installment',
-                    },
-                    {
-                      Value: 2362.5,
-                      InterestRate: 0,
-                      TotalValuePlusInterestRate: 9450,
-                      NumberOfInstallments: 4,
-                      Name: 'Customer Credit 4 vezes sem juros',
-                      __typename: 'vtex_storegraphql_2_76_0_Installment',
-                    },
-                    {
-                      Value: 1890,
-                      InterestRate: 0,
-                      TotalValuePlusInterestRate: 9450,
-                      NumberOfInstallments: 5,
-                      Name: 'Customer Credit 5 vezes sem juros',
-                      __typename: 'vtex_storegraphql_2_76_0_Installment',
-                    },
-                    {
-                      Value: 1861.9,
-                      InterestRate: 5,
-                      TotalValuePlusInterestRate: 11171.4,
-                      NumberOfInstallments: 6,
-                      Name: 'Customer Credit 6 vezes com juros',
-                      __typename: 'vtex_storegraphql_2_76_0_Installment',
-                    },
-                    {
-                      Value: 1771.4,
-                      InterestRate: 10,
-                      TotalValuePlusInterestRate: 14171.2,
-                      NumberOfInstallments: 8,
-                      Name: 'Customer Credit 8 vezes com juros',
-                      __typename: 'vtex_storegraphql_2_76_0_Installment',
-                    },
-                    {
-                      Value: 9450,
-                      InterestRate: 0,
-                      TotalValuePlusInterestRate: 9450,
-                      NumberOfInstallments: 1,
-                      Name: 'Free à vista',
-                      __typename: 'vtex_storegraphql_2_76_0_Installment',
-                    },
+                      "Value": 13,
+                      "InterestRate": 0,
+                      "TotalValuePlusInterestRate": 38.9,
+                      "NumberOfInstallments": 3,
+                      "Name": "Customer Credit 3 vezes sem juros",
+                      "__typename": "Installment"
+                    }
                   ],
-                  AvailableQuantity: 2000000,
-                  Price: 9450,
-                  ListPrice: 9450,
-                  __typename: 'vtex_storegraphql_2_76_0_Offer',
+                  "AvailableQuantity": 2000000,
+                  "Price": 38.9,
+                  "ListPrice": 38.9,
+                  "__typename": "Offer"
                 },
-                __typename: 'vtex_storegraphql_2_76_0_Seller',
-              },
+                "__typename": "Seller"
+              }
             ],
-            __typename: 'vtex_storegraphql_2_76_0_SKU',
+            "__typename": "SKU"
           },
-        ],
-        productClusters: [],
-        __typename: 'vtex_storegraphql_2_76_0_Product',
-        sku: {
-          name: 'Regular',
-          itemId: '2000539',
-          referenceId: {
-            Value: '98123719',
-            __typename: 'vtex_storegraphql_2_76_0_Reference',
-          },
-          images: [
-            {
-              imageUrl:
-                'https://storecomponents.vteximg.com.br/arquivos/ids/155487/Frame-7.jpg?v=636793837686400000',
-              imageTag:
-                '<img src="~/arquivos/ids/155487-#width#-#height#/Frame-7.jpg?v=636793837686400000" width="#width#" height="#height#" alt="Frame-7" id="" />',
-              __typename: 'vtex_storegraphql_2_76_0_Image',
-            },
-          ],
-          sellers: [
-            {
-              sellerId: '1',
-              commertialOffer: {
-                Installments: [
-                  {
-                    Value: 9450,
-                    InterestRate: 0,
-                    TotalValuePlusInterestRate: 9450,
-                    NumberOfInstallments: 1,
-                    Name: 'American Express à vista',
-                    __typename: 'vtex_storegraphql_2_76_0_Installment',
-                  },
-                  {
-                    Value: 9450,
-                    InterestRate: 0,
-                    TotalValuePlusInterestRate: 9450,
-                    NumberOfInstallments: 1,
-                    Name: 'Visa à vista',
-                    __typename: 'vtex_storegraphql_2_76_0_Installment',
-                  },
-                  {
-                    Value: 4725,
-                    InterestRate: 0,
-                    TotalValuePlusInterestRate: 9450,
-                    NumberOfInstallments: 2,
-                    Name: 'Visa 2 vezes sem juros',
-                    __typename: 'vtex_storegraphql_2_76_0_Installment',
-                  },
-                  {
-                    Value: 3150,
-                    InterestRate: 0,
-                    TotalValuePlusInterestRate: 9450,
-                    NumberOfInstallments: 3,
-                    Name: 'Visa 3 vezes sem juros',
-                    __typename: 'vtex_storegraphql_2_76_0_Installment',
-                  },
-                  {
-                    Value: 2362.5,
-                    InterestRate: 0,
-                    TotalValuePlusInterestRate: 9450,
-                    NumberOfInstallments: 4,
-                    Name: 'Visa 4 vezes sem juros',
-                    __typename: 'vtex_storegraphql_2_76_0_Installment',
-                  },
-                  {
-                    Value: 1890,
-                    InterestRate: 0,
-                    TotalValuePlusInterestRate: 9450,
-                    NumberOfInstallments: 5,
-                    Name: 'Visa 5 vezes sem juros',
-                    __typename: 'vtex_storegraphql_2_76_0_Installment',
-                  },
-                  {
-                    Value: 1575,
-                    InterestRate: 0,
-                    TotalValuePlusInterestRate: 9450,
-                    NumberOfInstallments: 6,
-                    Name: 'Visa 6 vezes sem juros',
-                    __typename: 'vtex_storegraphql_2_76_0_Installment',
-                  },
-                  {
-                    Value: 9450,
-                    InterestRate: 0,
-                    TotalValuePlusInterestRate: 9450,
-                    NumberOfInstallments: 1,
-                    Name: 'Mastercard à vista',
-                    __typename: 'vtex_storegraphql_2_76_0_Installment',
-                  },
-                  {
-                    Value: 4725,
-                    InterestRate: 0,
-                    TotalValuePlusInterestRate: 9450,
-                    NumberOfInstallments: 2,
-                    Name: 'Mastercard 2 vezes sem juros',
-                    __typename: 'vtex_storegraphql_2_76_0_Installment',
-                  },
-                  {
-                    Value: 3150,
-                    InterestRate: 0,
-                    TotalValuePlusInterestRate: 9450,
-                    NumberOfInstallments: 3,
-                    Name: 'Mastercard 3 vezes sem juros',
-                    __typename: 'vtex_storegraphql_2_76_0_Installment',
-                  },
-                  {
-                    Value: 2362.5,
-                    InterestRate: 0,
-                    TotalValuePlusInterestRate: 9450,
-                    NumberOfInstallments: 4,
-                    Name: 'Mastercard 4 vezes sem juros',
-                    __typename: 'vtex_storegraphql_2_76_0_Installment',
-                  },
-                  {
-                    Value: 1890,
-                    InterestRate: 0,
-                    TotalValuePlusInterestRate: 9450,
-                    NumberOfInstallments: 5,
-                    Name: 'Mastercard 5 vezes sem juros',
-                    __typename: 'vtex_storegraphql_2_76_0_Installment',
-                  },
-                  {
-                    Value: 1575,
-                    InterestRate: 0,
-                    TotalValuePlusInterestRate: 9450,
-                    NumberOfInstallments: 6,
-                    Name: 'Mastercard 6 vezes sem juros',
-                    __typename: 'vtex_storegraphql_2_76_0_Installment',
-                  },
-                  {
-                    Value: 9450,
-                    InterestRate: 0,
-                    TotalValuePlusInterestRate: 9450,
-                    NumberOfInstallments: 1,
-                    Name: 'Boleto Bancário à vista',
-                    __typename: 'vtex_storegraphql_2_76_0_Installment',
-                  },
-                  {
-                    Value: 9450,
-                    InterestRate: 0,
-                    TotalValuePlusInterestRate: 9450,
-                    NumberOfInstallments: 1,
-                    Name: 'Promissory à vista',
-                    __typename: 'vtex_storegraphql_2_76_0_Installment',
-                  },
-                  {
-                    Value: 9450,
-                    InterestRate: 0,
-                    TotalValuePlusInterestRate: 9450,
-                    NumberOfInstallments: 1,
-                    Name: 'Customer Credit à vista',
-                    __typename: 'vtex_storegraphql_2_76_0_Installment',
-                  },
-                  {
-                    Value: 4725,
-                    InterestRate: 0,
-                    TotalValuePlusInterestRate: 9450,
-                    NumberOfInstallments: 2,
-                    Name: 'Customer Credit 2 vezes sem juros',
-                    __typename: 'vtex_storegraphql_2_76_0_Installment',
-                  },
-                  {
-                    Value: 3150,
-                    InterestRate: 0,
-                    TotalValuePlusInterestRate: 9450,
-                    NumberOfInstallments: 3,
-                    Name: 'Customer Credit 3 vezes sem juros',
-                    __typename: 'vtex_storegraphql_2_76_0_Installment',
-                  },
-                  {
-                    Value: 2362.5,
-                    InterestRate: 0,
-                    TotalValuePlusInterestRate: 9450,
-                    NumberOfInstallments: 4,
-                    Name: 'Customer Credit 4 vezes sem juros',
-                    __typename: 'vtex_storegraphql_2_76_0_Installment',
-                  },
-                  {
-                    Value: 1890,
-                    InterestRate: 0,
-                    TotalValuePlusInterestRate: 9450,
-                    NumberOfInstallments: 5,
-                    Name: 'Customer Credit 5 vezes sem juros',
-                    __typename: 'vtex_storegraphql_2_76_0_Installment',
-                  },
-                  {
-                    Value: 1861.9,
-                    InterestRate: 5,
-                    TotalValuePlusInterestRate: 11171.4,
-                    NumberOfInstallments: 6,
-                    Name: 'Customer Credit 6 vezes com juros',
-                    __typename: 'vtex_storegraphql_2_76_0_Installment',
-                  },
-                  {
-                    Value: 1771.4,
-                    InterestRate: 10,
-                    TotalValuePlusInterestRate: 14171.2,
-                    NumberOfInstallments: 8,
-                    Name: 'Customer Credit 8 vezes com juros',
-                    __typename: 'vtex_storegraphql_2_76_0_Installment',
-                  },
-                  {
-                    Value: 9450,
-                    InterestRate: 0,
-                    TotalValuePlusInterestRate: 9450,
-                    NumberOfInstallments: 1,
-                    Name: 'Free à vista',
-                    __typename: 'vtex_storegraphql_2_76_0_Installment',
-                  },
-                ],
-                AvailableQuantity: 2000000,
-                Price: 9450,
-                ListPrice: 9450,
-                __typename: 'vtex_storegraphql_2_76_0_Offer',
+          {
+            "name": "White Slip On",
+            "itemId": "36",
+            "measurementUnit": "un",
+            "unitMultiplier": 1,
+            "referenceId": [
+              {
+                "Value": "12532",
+                "__typename": "Reference"
+              }
+            ],
+            "images": [
+              {
+                "imageUrl": "https://storecomponents.vteximg.com.br/arquivos/ids/155472/Frame-3.jpg?v=636793763985400000",
+                "imageTag": "<img src=\"~/arquivos/ids/155472-#width#-#height#/Frame-3.jpg?v=636793763985400000\" width=\"#width#\" height=\"#height#\" alt=\"Frame-3\" id=\"\" />",
+                "imageLabel": "",
+                "__typename": "Image"
               },
-              __typename: 'vtex_storegraphql_2_76_0_Seller',
+              {
+                "imageUrl": "https://storecomponents.vteximg.com.br/arquivos/ids/155473/Frame.jpg?v=636793764101900000",
+                "imageTag": "<img src=\"~/arquivos/ids/155473-#width#-#height#/Frame.jpg?v=636793764101900000\" width=\"#width#\" height=\"#height#\" alt=\"Frame\" id=\"\" />",
+                "imageLabel": "",
+                "__typename": "Image"
+              }
+            ],
+            "sellers": [
+              {
+                "sellerId": "1",
+                "commertialOffer": {
+                  "Installments": [
+                    {
+                      "Value": 43.8,
+                      "InterestRate": 0,
+                      "TotalValuePlusInterestRate": 262.5,
+                      "NumberOfInstallments": 6,
+                      "Name": "Mastercard 6 vezes sem juros",
+                      "__typename": "Installment"
+                    }
+                  ],
+                  "AvailableQuantity": 2000000,
+                  "Price": 262.5,
+                  "ListPrice": 262.5,
+                  "__typename": "Offer"
+                },
+                "__typename": "Seller"
+              }
+            ],
+            "__typename": "SKU"
+          },
+          {
+            "name": "Cool Pink",
+            "itemId": "37",
+            "measurementUnit": "un",
+            "unitMultiplier": 1,
+            "referenceId": [
+              {
+                "Value": "12533",
+                "__typename": "Reference"
+              }
+            ],
+            "images": [
+              {
+                "imageUrl": "https://storecomponents.vteximg.com.br/arquivos/ids/155474/Frame-1.jpg?v=636793764631500000",
+                "imageTag": "<img src=\"~/arquivos/ids/155474-#width#-#height#/Frame-1.jpg?v=636793764631500000\" width=\"#width#\" height=\"#height#\" alt=\"Frame-1\" id=\"\" />",
+                "imageLabel": "",
+                "__typename": "Image"
+              },
+              {
+                "imageUrl": "https://storecomponents.vteximg.com.br/arquivos/ids/155475/Frame-2.jpg?v=636793764763600000",
+                "imageTag": "<img src=\"~/arquivos/ids/155475-#width#-#height#/Frame-2.jpg?v=636793764763600000\" width=\"#width#\" height=\"#height#\" alt=\"Frame-2\" id=\"\" />",
+                "imageLabel": "",
+                "__typename": "Image"
+              }
+            ],
+            "sellers": [
+              {
+                "sellerId": "1",
+                "commertialOffer": {
+                  "Installments": [
+                    {
+                      "Value": 3.5,
+                      "InterestRate": 0,
+                      "TotalValuePlusInterestRate": 10.5,
+                      "NumberOfInstallments": 3,
+                      "Name": "Customer Credit 3 vezes sem juros",
+                      "__typename": "Installment"
+                    }
+                  ],
+                  "AvailableQuantity": 1000000,
+                  "Price": 10.5,
+                  "ListPrice": 10.5,
+                  "__typename": "Offer"
+                },
+                "__typename": "Seller"
+              }
+            ],
+            "__typename": "SKU"
+          }
+        ],
+        "productClusters": [],
+        "properties": [],
+        "__typename": "Product",
+        "sku": {
+          "name": "Classic Pink",
+          "itemId": "35",
+          "measurementUnit": "un",
+          "unitMultiplier": 1,
+          "referenceId": {
+            "Value": "12531",
+            "__typename": "Reference"
+          },
+          "images": [
+            {
+              "imageUrl": "https://storecomponents.vteximg.com.br/arquivos/ids/155470/Frame-11.jpg?v=636793763155730000",
+              "imageTag": "<img src=\"~/arquivos/ids/155470-#width#-#height#/Frame-11.jpg?v=636793763155730000\" width=\"#width#\" height=\"#height#\" alt=\"Frame-11\" id=\"\" />",
+              "imageLabel": "",
+              "__typename": "Image"
             },
+            {
+              "imageUrl": "https://storecomponents.vteximg.com.br/arquivos/ids/155471/Frame-10.jpg?v=637018188181300000",
+              "imageTag": "<img src=\"~/arquivos/ids/155471-#width#-#height#/Frame-10.jpg?v=637018188181300000\" width=\"#width#\" height=\"#height#\" alt=\"Frame-10\" id=\"\" />",
+              "imageLabel": "",
+              "__typename": "Image"
+            }
           ],
-          __typename: 'vtex_storegraphql_2_76_0_SKU',
-          seller: {
-            sellerId: '1',
-            commertialOffer: {
-              Installments: [
+          "sellers": [
+            {
+              "sellerId": "1",
+              "commertialOffer": {
+                "Installments": [
+                  {
+                    "Value": 13,
+                    "InterestRate": 0,
+                    "TotalValuePlusInterestRate": 38.9,
+                    "NumberOfInstallments": 3,
+                    "Name": "Customer Credit 3 vezes sem juros",
+                    "__typename": "Installment"
+                  }
+                ],
+                "AvailableQuantity": 2000000,
+                "Price": 38.9,
+                "ListPrice": 38.9,
+                "__typename": "Offer"
+              },
+              "__typename": "Seller"
+            }
+          ],
+          "__typename": "SKU",
+          "seller": {
+            "sellerId": "1",
+            "commertialOffer": {
+              "Installments": [
                 {
-                  Value: 9450,
-                  InterestRate: 0,
-                  TotalValuePlusInterestRate: 9450,
-                  NumberOfInstallments: 1,
-                  Name: 'American Express à vista',
-                  __typename: 'vtex_storegraphql_2_76_0_Installment',
-                },
-                {
-                  Value: 9450,
-                  InterestRate: 0,
-                  TotalValuePlusInterestRate: 9450,
-                  NumberOfInstallments: 1,
-                  Name: 'Visa à vista',
-                  __typename: 'vtex_storegraphql_2_76_0_Installment',
-                },
-                {
-                  Value: 4725,
-                  InterestRate: 0,
-                  TotalValuePlusInterestRate: 9450,
-                  NumberOfInstallments: 2,
-                  Name: 'Visa 2 vezes sem juros',
-                  __typename: 'vtex_storegraphql_2_76_0_Installment',
-                },
-                {
-                  Value: 3150,
-                  InterestRate: 0,
-                  TotalValuePlusInterestRate: 9450,
-                  NumberOfInstallments: 3,
-                  Name: 'Visa 3 vezes sem juros',
-                  __typename: 'vtex_storegraphql_2_76_0_Installment',
-                },
-                {
-                  Value: 2362.5,
-                  InterestRate: 0,
-                  TotalValuePlusInterestRate: 9450,
-                  NumberOfInstallments: 4,
-                  Name: 'Visa 4 vezes sem juros',
-                  __typename: 'vtex_storegraphql_2_76_0_Installment',
-                },
-                {
-                  Value: 1890,
-                  InterestRate: 0,
-                  TotalValuePlusInterestRate: 9450,
-                  NumberOfInstallments: 5,
-                  Name: 'Visa 5 vezes sem juros',
-                  __typename: 'vtex_storegraphql_2_76_0_Installment',
-                },
-                {
-                  Value: 1575,
-                  InterestRate: 0,
-                  TotalValuePlusInterestRate: 9450,
-                  NumberOfInstallments: 6,
-                  Name: 'Visa 6 vezes sem juros',
-                  __typename: 'vtex_storegraphql_2_76_0_Installment',
-                },
-                {
-                  Value: 9450,
-                  InterestRate: 0,
-                  TotalValuePlusInterestRate: 9450,
-                  NumberOfInstallments: 1,
-                  Name: 'Mastercard à vista',
-                  __typename: 'vtex_storegraphql_2_76_0_Installment',
-                },
-                {
-                  Value: 4725,
-                  InterestRate: 0,
-                  TotalValuePlusInterestRate: 9450,
-                  NumberOfInstallments: 2,
-                  Name: 'Mastercard 2 vezes sem juros',
-                  __typename: 'vtex_storegraphql_2_76_0_Installment',
-                },
-                {
-                  Value: 3150,
-                  InterestRate: 0,
-                  TotalValuePlusInterestRate: 9450,
-                  NumberOfInstallments: 3,
-                  Name: 'Mastercard 3 vezes sem juros',
-                  __typename: 'vtex_storegraphql_2_76_0_Installment',
-                },
-                {
-                  Value: 2362.5,
-                  InterestRate: 0,
-                  TotalValuePlusInterestRate: 9450,
-                  NumberOfInstallments: 4,
-                  Name: 'Mastercard 4 vezes sem juros',
-                  __typename: 'vtex_storegraphql_2_76_0_Installment',
-                },
-                {
-                  Value: 1890,
-                  InterestRate: 0,
-                  TotalValuePlusInterestRate: 9450,
-                  NumberOfInstallments: 5,
-                  Name: 'Mastercard 5 vezes sem juros',
-                  __typename: 'vtex_storegraphql_2_76_0_Installment',
-                },
-                {
-                  Value: 1575,
-                  InterestRate: 0,
-                  TotalValuePlusInterestRate: 9450,
-                  NumberOfInstallments: 6,
-                  Name: 'Mastercard 6 vezes sem juros',
-                  __typename: 'vtex_storegraphql_2_76_0_Installment',
-                },
-                {
-                  Value: 9450,
-                  InterestRate: 0,
-                  TotalValuePlusInterestRate: 9450,
-                  NumberOfInstallments: 1,
-                  Name: 'Boleto Bancário à vista',
-                  __typename: 'vtex_storegraphql_2_76_0_Installment',
-                },
-                {
-                  Value: 9450,
-                  InterestRate: 0,
-                  TotalValuePlusInterestRate: 9450,
-                  NumberOfInstallments: 1,
-                  Name: 'Promissory à vista',
-                  __typename: 'vtex_storegraphql_2_76_0_Installment',
-                },
-                {
-                  Value: 9450,
-                  InterestRate: 0,
-                  TotalValuePlusInterestRate: 9450,
-                  NumberOfInstallments: 1,
-                  Name: 'Customer Credit à vista',
-                  __typename: 'vtex_storegraphql_2_76_0_Installment',
-                },
-                {
-                  Value: 4725,
-                  InterestRate: 0,
-                  TotalValuePlusInterestRate: 9450,
-                  NumberOfInstallments: 2,
-                  Name: 'Customer Credit 2 vezes sem juros',
-                  __typename: 'vtex_storegraphql_2_76_0_Installment',
-                },
-                {
-                  Value: 3150,
-                  InterestRate: 0,
-                  TotalValuePlusInterestRate: 9450,
-                  NumberOfInstallments: 3,
-                  Name: 'Customer Credit 3 vezes sem juros',
-                  __typename: 'vtex_storegraphql_2_76_0_Installment',
-                },
-                {
-                  Value: 2362.5,
-                  InterestRate: 0,
-                  TotalValuePlusInterestRate: 9450,
-                  NumberOfInstallments: 4,
-                  Name: 'Customer Credit 4 vezes sem juros',
-                  __typename: 'vtex_storegraphql_2_76_0_Installment',
-                },
-                {
-                  Value: 1890,
-                  InterestRate: 0,
-                  TotalValuePlusInterestRate: 9450,
-                  NumberOfInstallments: 5,
-                  Name: 'Customer Credit 5 vezes sem juros',
-                  __typename: 'vtex_storegraphql_2_76_0_Installment',
-                },
-                {
-                  Value: 1861.9,
-                  InterestRate: 5,
-                  TotalValuePlusInterestRate: 11171.4,
-                  NumberOfInstallments: 6,
-                  Name: 'Customer Credit 6 vezes com juros',
-                  __typename: 'vtex_storegraphql_2_76_0_Installment',
-                },
-                {
-                  Value: 1771.4,
-                  InterestRate: 10,
-                  TotalValuePlusInterestRate: 14171.2,
-                  NumberOfInstallments: 8,
-                  Name: 'Customer Credit 8 vezes com juros',
-                  __typename: 'vtex_storegraphql_2_76_0_Installment',
-                },
-                {
-                  Value: 9450,
-                  InterestRate: 0,
-                  TotalValuePlusInterestRate: 9450,
-                  NumberOfInstallments: 1,
-                  Name: 'Free à vista',
-                  __typename: 'vtex_storegraphql_2_76_0_Installment',
-                },
+                  "Value": 13,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 38.9,
+                  "NumberOfInstallments": 3,
+                  "Name": "Customer Credit 3 vezes sem juros",
+                  "__typename": "Installment"
+                }
               ],
-              AvailableQuantity: 2000000,
-              Price: 9450,
-              ListPrice: 9450,
-              __typename: 'vtex_storegraphql_2_76_0_Offer',
+              "AvailableQuantity": 2000000,
+              "Price": 38.9,
+              "ListPrice": 38.9,
+              "__typename": "Offer"
             },
-            __typename: 'vtex_storegraphql_2_76_0_Seller',
+            "__typename": "Seller"
           },
-          image: {
-            imageUrl:
-              'https://storecomponents.vteximg.com.br/arquivos/ids/155487-500-auto?width=500&height=auto&aspect=true',
-            imageTag:
-              '<img src="~/arquivos/ids/155487-#width#-#height#/Frame-7.jpg?v=636793837686400000" width="#width#" height="#height#" alt="Frame-7" id="" />',
-            __typename: 'vtex_storegraphql_2_76_0_Image',
-          },
-        },
+          "image": {
+            "imageUrl": "https://storecomponents.vteximg.com.br/arquivos/ids/155470-500-auto?width=500&height=auto&aspect=true",
+            "imageTag": "<img src=\"~/arquivos/ids/155470-#width#-#height#/Frame-11.jpg?v=636793763155730000\" width=\"#width#\" height=\"#height#\" alt=\"Frame-11\" id=\"\" />",
+            "imageLabel": "",
+            "__typename": "Image"
+          }
+        }
       },
+      "position": 1
     },
-  ],
+    {
+      "product": {
+        "cacheId": "gorgeous-watch",
+        "productId": "15",
+        "productName": "Gorgeous Top Watch",
+        "productReference": "1234",
+        "description": "A classic and gorgeous watch",
+        "categories": [
+          "/Apparel & Accessories/Watches/",
+          "/Apparel & Accessories/"
+        ],
+        "link": "https://portal.vtexcommercestable.com.br/gorgeous-watch/p",
+        "linkText": "gorgeous-watch",
+        "brand": "Nintendo",
+        "brandId": 2000008,
+        "items": [
+          {
+            "name": "Grey",
+            "itemId": "32",
+            "measurementUnit": "un",
+            "unitMultiplier": 1,
+            "referenceId": [
+              {
+                "Value": "1234",
+                "__typename": "Reference"
+              }
+            ],
+            "images": [
+              {
+                "imageUrl": "https://storecomponents.vteximg.com.br/arquivos/ids/155456/Frame-1.jpg?v=636793737258100000",
+                "imageTag": "<img src=\"~/arquivos/ids/155456-#width#-#height#/Frame-1.jpg?v=636793737258100000\" width=\"#width#\" height=\"#height#\" alt=\"Frame-1\" id=\"\" />",
+                "imageLabel": "",
+                "__typename": "Image"
+              }
+            ],
+            "sellers": [
+              {
+                "sellerId": "1",
+                "commertialOffer": {
+                  "Installments": [
+                    {
+                      "Value": 366.7,
+                      "InterestRate": 0,
+                      "TotalValuePlusInterestRate": 2200,
+                      "NumberOfInstallments": 6,
+                      "Name": "Mastercard 6 vezes sem juros",
+                      "__typename": "Installment"
+                    }
+                  ],
+                  "AvailableQuantity": 2000000,
+                  "Price": 2200,
+                  "ListPrice": 2300,
+                  "__typename": "Offer"
+                },
+                "__typename": "Seller"
+              }
+            ],
+            "__typename": "SKU"
+          }
+        ],
+        "productClusters": [],
+        "properties": [],
+        "__typename": "Product",
+        "sku": {
+          "name": "Grey",
+          "itemId": "32",
+          "measurementUnit": "un",
+          "unitMultiplier": 1,
+          "referenceId": {
+            "Value": "1234",
+            "__typename": "Reference"
+          },
+          "images": [
+            {
+              "imageUrl": "https://storecomponents.vteximg.com.br/arquivos/ids/155456/Frame-1.jpg?v=636793737258100000",
+              "imageTag": "<img src=\"~/arquivos/ids/155456-#width#-#height#/Frame-1.jpg?v=636793737258100000\" width=\"#width#\" height=\"#height#\" alt=\"Frame-1\" id=\"\" />",
+              "imageLabel": "",
+              "__typename": "Image"
+            }
+          ],
+          "sellers": [
+            {
+              "sellerId": "1",
+              "commertialOffer": {
+                "Installments": [
+                  {
+                    "Value": 366.7,
+                    "InterestRate": 0,
+                    "TotalValuePlusInterestRate": 2200,
+                    "NumberOfInstallments": 6,
+                    "Name": "Mastercard 6 vezes sem juros",
+                    "__typename": "Installment"
+                  }
+                ],
+                "AvailableQuantity": 2000000,
+                "Price": 2200,
+                "ListPrice": 2300,
+                "__typename": "Offer"
+              },
+              "__typename": "Seller"
+            }
+          ],
+          "__typename": "SKU",
+          "seller": {
+            "sellerId": "1",
+            "commertialOffer": {
+              "Installments": [
+                {
+                  "Value": 366.7,
+                  "InterestRate": 0,
+                  "TotalValuePlusInterestRate": 2200,
+                  "NumberOfInstallments": 6,
+                  "Name": "Mastercard 6 vezes sem juros",
+                  "__typename": "Installment"
+                }
+              ],
+              "AvailableQuantity": 2000000,
+              "Price": 2200,
+              "ListPrice": 2300,
+              "__typename": "Offer"
+            },
+            "__typename": "Seller"
+          },
+          "image": {
+            "imageUrl": "https://storecomponents.vteximg.com.br/arquivos/ids/155456-500-auto?width=500&height=auto&aspect=true",
+            "imageTag": "<img src=\"~/arquivos/ids/155456-#width#-#height#/Frame-1.jpg?v=636793737258100000\" width=\"#width#\" height=\"#height#\" alt=\"Frame-1\" id=\"\" />",
+            "imageLabel": "",
+            "__typename": "Image"
+          }
+        }
+      },
+      "position": 2
+    },
+  ]
 }
 
 export default productImpression

--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -1,8 +1,16 @@
 import productImpressionData from '../__mocks__/productImpression'
+import productDetails from '../__mocks__/productDetail'
+import productClick from '../__mocks__/productClick'
 import { handleEvents } from '../index'
 import push from '../modules/push'
 
 jest.mock('../modules/push', () => jest.fn())
+
+const mockedPush = push as jest.Mock
+
+beforeEach(() => {
+  mockedPush.mockReset()
+})
 
 test('productImpression', () => {
   const message = new MessageEvent('message', {
@@ -11,22 +19,84 @@ test('productImpression', () => {
 
   handleEvents(message)
 
-  expect(push).toHaveBeenCalledWith({
+  expect(mockedPush).toHaveBeenCalledWith({
     event: 'productImpression',
     ecommerce: {
       currencyCode: 'USD',
       impressions: [
         {
-          name: 'Long Sleeve Shirt - Regular',
-          id: '2000005',
-          price: '9450',
-          brand: 'Apple',
-          category: 'Clothing',
-          variant: 'Regular',
+          brand: 'Mizuno',
+          category: 'Apparel & Accessories/Shoes',
+          id: '35',
           list: 'Shelf',
-          position: 3,
+          name: 'Classic Shoes Top',
+          position: 1,
+          price: '38.9',
+          variant: 'Classic Pink',
+        },
+        {
+          brand: 'Nintendo',
+          category: 'Apparel & Accessories/Watches',
+          id: '32',
+          list: 'Shelf',
+          name: 'Gorgeous Top Watch',
+          position: 2,
+          price: '2200',
+          variant: 'Grey',
         },
       ],
     },
+  })
+})
+
+test('productDetail', () => {
+  const message = new MessageEvent('message', {
+    data: productDetails,
+  })
+
+  handleEvents(message)
+
+  expect(mockedPush).toHaveBeenCalledWith({
+    event: 'productDetail',
+    ecommerce: {
+      detail: {
+        products: [
+          {
+            brand: 'Mizuno',
+            category: 'Apparel & Accessories/Shoes',
+            id: '35',
+            name: 'Classic Shoes Top',
+            price: 38.9,
+            variant: 'Classic Pink',
+          },
+        ],
+      }
+    },
+  })
+})
+
+test('productClick', () => {
+  const message = new MessageEvent('message', {
+    data: productClick
+  })
+
+  handleEvents(message)
+
+  expect(mockedPush).toHaveBeenCalledWith({
+    event: 'productClick',
+    ecommerce: {
+      click: {
+        products: [
+          {
+            brand: 'Mizuno',
+            category: 'Apparel & Accessories/Shoes',
+            id: '35',
+            name: 'Classic Shoes Top',
+            price: 38.9,
+            variant: 'Classic Pink',
+          }
+        ]
+      }
+    }
   })
 })

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -22,7 +22,7 @@ export function handleEvents(e: PixelMessage) {
       return
     }
     case 'vtex:productView': {
-      const { productId, productName, brand, categories } = e.data.product
+      const { selectedSku, productName, brand, categories } = e.data.product
 
       let price
       try {
@@ -38,8 +38,9 @@ export function handleEvents(e: PixelMessage) {
               {
                 brand,
                 category: getCategory(categories),
-                id: productId,
+                id: selectedSku.itemId,
                 name: productName,
+                variant: selectedSku.name,
                 price,
               },
             ],
@@ -52,7 +53,7 @@ export function handleEvents(e: PixelMessage) {
       return
     }
     case 'vtex:productClick': {
-      const { productId, productName, brand, categories, sku } = e.data.product
+      const { productName, brand, categories, sku } = e.data.product
 
       let price
       try {
@@ -69,7 +70,7 @@ export function handleEvents(e: PixelMessage) {
               {
                 brand,
                 category: getCategory(categories),
-                id: productId,
+                id: sku.itemId,
                 name: productName,
                 variant: sku.name,
                 price,
@@ -227,7 +228,7 @@ const getProductImpressionObjectData = (list: string) => ({
 }: Impression) => ({
   brand: product.brand,
   category: getCategory(product.categories),
-  id: product.productId,
+  id: product.sku.itemId,
   list,
   name: product.productName,
   position,

--- a/react/typings/events.d.ts
+++ b/react/typings/events.d.ts
@@ -43,13 +43,13 @@ export interface OrderPlacedData extends Order, EventData {
 export interface ProductViewData extends EventData {
   event: 'productView'
   eventName: 'vtex:productView'
-  product: Product
+  product: ProductDetail
 }
 
 export interface ProductClickData extends EventData {
   event: 'productClick'
   eventName: 'vtex:productClick'
-  product: ProductDetail
+  product: ProductSummary
 }
 
 export interface ProductImpressionData extends EventData {
@@ -101,7 +101,7 @@ export interface Order {
 }
 
 export interface Impression {
-  product: Product
+  product: ProductSummary
   position: number
 }
 
@@ -158,8 +158,11 @@ interface Product {
   productId: string
   productName: string
   items: Item[]
-  sku: Item
   [key: string]: any
+}
+
+interface ProductSummary extends Product {
+  sku: Item
 }
 
 interface ProductDetail extends Product {

--- a/react/typings/events.d.ts
+++ b/react/typings/events.d.ts
@@ -56,7 +56,7 @@ export interface ProductImpressionData extends EventData {
   event: 'productImpression'
   eventName: 'vtex:productImpression'
   impressions: Impression[]
-  product?: Product // deprecated, use impressions list!
+  product?: ProductSummary // deprecated, use impressions list!
   position?: number // deprecated, use impressions list!
   list: string
 }

--- a/react/typings/events.d.ts
+++ b/react/typings/events.d.ts
@@ -49,7 +49,7 @@ export interface ProductViewData extends EventData {
 export interface ProductClickData extends EventData {
   event: 'productClick'
   eventName: 'vtex:productClick'
-  product: Product
+  product: ProductDetail
 }
 
 export interface ProductImpressionData extends EventData {
@@ -157,10 +157,13 @@ interface Product {
   categories: string[]
   productId: string
   productName: string
-  selectedSku?: string // inconsistency
   items: Item[]
   sku: Item
   [key: string]: any
+}
+
+interface ProductDetail extends Product {
+  selectedSku: Item
 }
 
 interface Item {


### PR DESCRIPTION
#### What is the purpose of this pull request?

The ids sent by this app was inconsistent across navigation. Sometimes we sent the id of the product and some times the id of the SKU. Now, all events are sent using the id of the visible SKU.

#### How should this be manually tested?

Before | After
---|---
![image](https://user-images.githubusercontent.com/284515/64385074-8f11bc80-d00c-11e9-9880-f04efcfe41a3.png) | ![image](https://user-images.githubusercontent.com/284515/64381405-7eac1280-d009-11e9-8f9d-307ec1c87dc7.png)
![image](https://user-images.githubusercontent.com/284515/64385276-9c2eab80-d00c-11e9-9ccb-94c37337a542.png) | ![image](https://user-images.githubusercontent.com/284515/64381451-984d5a00-d009-11e9-9a81-51f74183b9d2.png)
![image](https://user-images.githubusercontent.com/284515/64385367-a3ee5000-d00c-11e9-980b-55464da72fe5.png) | ![image](https://user-images.githubusercontent.com/284515/64383716-3c380500-d00c-11e9-8ea5-4506c8b1df14.png)


#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
