### PR TITLE
Fix events typings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Events typings.
 
 ## [2.2.0] - 2019-09-12
 ### Changed

--- a/react/__mocks__/productClick.ts
+++ b/react/__mocks__/productClick.ts
@@ -1,6 +1,4 @@
-import { ProductClickData } from '../typings/events'
-
-const productClick: ProductClickData = {
+const productClick = {
   "currency": "USD",
   "eventName": "vtex:productClick",
   "event": "productClick",

--- a/react/__mocks__/productDetail.ts
+++ b/react/__mocks__/productDetail.ts
@@ -1,6 +1,4 @@
-import { ProductViewData } from '../typings/events'
-
-const productDetail: ProductViewData = {
+const productDetail = {
   "currency": "USD",
   "eventName": "vtex:productView",
   "event": "productView",

--- a/react/__mocks__/productImpression.ts
+++ b/react/__mocks__/productImpression.ts
@@ -1,7 +1,4 @@
-// @ts-ignore
-import { ProductImpressionData } from '../typings/events'
-
-const productImpression: ProductImpressionData = {
+const productImpression = {
   "currency": "USD",
   "eventName": "vtex:productImpression",
   "event": "productImpression",

--- a/react/package.json
+++ b/react/package.json
@@ -17,6 +17,6 @@
     "eslint": "^5.16.0",
     "eslint-config-vtex": "^10.1.0",
     "prettier": "^1.17.1",
-    "typescript": "3.5.2"
+    "typescript": "3.7.3"
   }
 }

--- a/react/typings/events.d.ts
+++ b/react/typings/events.d.ts
@@ -7,12 +7,59 @@ export interface PixelMessage extends MessageEvent {
     | ProductImpressionData
     | AddToCartData
     | RemoveToCartData
+    | CartChangedData
+    | HomePageInfo
+    | ProductPageInfoData
+    | SearchPageInfoData
 }
 
 export interface EventData {
   event: string
   eventName: string
   currency: string
+}
+
+export interface PageInfoData extends EventData {
+  event: 'pageInfo'
+  eventName: 'vtex:pageInfo'
+  accountName: string
+  pageTitle: string
+  pageUrl: string
+}
+
+export interface HomePageInfo extends PageInfoData {
+  eventType: 'homeView'
+}
+
+export interface ProductPageInfoData extends PageInfoData {
+  eventType: 'productView'
+}
+
+export interface SearchPageInfoData extends PageInfoData {
+  eventType:
+    | 'internalSiteSearchView'
+    | 'categoryView'
+    | 'departmentView'
+    | 'emptySearchView'
+  category?: CategoryMetaData
+  department?: DepartmentMetaData
+  search?: SearchMetaData
+}
+
+interface CategoryMetaData {
+  id: string
+  name: string
+}
+
+interface DepartmentMetaData {
+  id: string
+  name: string
+}
+
+interface SearchMetaData {
+  term: string
+  category: CategoryMetaData
+  results: number
 }
 
 export interface PageViewData extends EventData {
@@ -32,6 +79,12 @@ export interface AddToCartData extends EventData {
 export interface RemoveToCartData extends EventData {
   event: 'removeFromCart'
   eventName: 'vtex:removeFromCart'
+  items: CartItem[]
+}
+
+export interface CartChangedData extends EventData {
+  event: 'cartChanged'
+  eventName: 'vtex:cartChanged'
   items: CartItem[]
 }
 
@@ -70,6 +123,8 @@ interface CartItem {
   productRefId: string
   brand: string
   category: string
+  detailUrl: string
+  imageUrl: string
 }
 
 export interface Order {
@@ -105,19 +160,19 @@ export interface Impression {
   position: number
 }
 
-interface PaymentType {
+export interface PaymentType {
   group: string
   paymentSystemName: string
   installments: number
   value: number
 }
 
-interface ShippingMethod {
+export interface ShippingMethod {
   itemId: string
   selectedSla: string
 }
 
-interface ProductOrder {
+export interface ProductOrder {
   id: string
   name: string
   sku: string
@@ -145,7 +200,7 @@ interface ProductOrder {
   unitMultiplier: number
 }
 
-interface PriceTag {
+export interface PriceTag {
   identifier: string
   isPercentual: boolean
   value: number
@@ -153,35 +208,41 @@ interface PriceTag {
 
 interface Product {
   brand: string
-  categoryId?: string // inconsistency
+  brandId: string
   categories: string[]
   productId: string
   productName: string
+  productReference: string
+  linkText: string
   items: Item[]
-  [key: string]: any
 }
 
-interface ProductSummary extends Product {
+export interface ProductSummary extends Product {
   sku: Item
 }
 
-interface ProductDetail extends Product {
+export interface ProductDetail extends Product {
+  categoryId: string
+  categoryTree: { id: string; name: string }[]
   selectedSku: Item
 }
 
-interface Item {
+export interface Item {
   itemId: string
   name: string
+  ean?: string // TODO: provide this info at productImpression
+  referenceId: { Key: string; Value: string }
   seller?: Seller
-  [key: string]: any
+  sellers: Seller[]
 }
 
-interface Seller {
+export interface Seller {
   commertialOffer: CommertialOffer
-  [key: string]: any
+  sellerId: string
 }
 
-interface CommertialOffer {
+export interface CommertialOffer {
   Price: number
-  [key: string]: any
+  ListPrice: number
+  AvailableQuantity: number
 }

--- a/react/typings/events.d.ts
+++ b/react/typings/events.d.ts
@@ -11,6 +11,7 @@ export interface PixelMessage extends MessageEvent {
     | HomePageInfo
     | ProductPageInfoData
     | SearchPageInfoData
+    | UserData
 }
 
 export interface EventData {
@@ -25,6 +26,18 @@ export interface PageInfoData extends EventData {
   accountName: string
   pageTitle: string
   pageUrl: string
+}
+
+export interface UserData extends PageInfoData {
+  eventType: 'userData'
+  eventName: 'vtex:userData'
+  firstName?: string
+  lastName?: string
+  document?: string
+  id?: string
+  email?: string
+  phone?: string
+  isAuthenticated: boolean
 }
 
 export interface HomePageInfo extends PageInfoData {

--- a/react/typings/events.d.ts
+++ b/react/typings/events.d.ts
@@ -12,6 +12,7 @@ export interface PixelMessage extends MessageEvent {
     | ProductPageInfoData
     | SearchPageInfoData
     | UserData
+    | CartIdData
 }
 
 export interface EventData {
@@ -38,6 +39,12 @@ export interface UserData extends PageInfoData {
   email?: string
   phone?: string
   isAuthenticated: boolean
+}
+
+export interface CartIdData extends PageInfoData {
+  eventType: 'cartId'
+  eventName: 'vtex:cartId'
+  cartId: string
 }
 
 export interface HomePageInfo extends PageInfoData {

--- a/react/typings/events.d.ts
+++ b/react/typings/events.d.ts
@@ -52,7 +52,7 @@ export interface HomePageInfo extends PageInfoData {
 }
 
 export interface ProductPageInfoData extends PageInfoData {
-  eventType: 'productView'
+  eventType: 'productPageInfo'
 }
 
 export interface SearchPageInfoData extends PageInfoData {

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4947,10 +4947,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
-  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
+typescript@3.7.3:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
+  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
 
 typescript@^3.3.3333:
   version "3.4.5"


### PR DESCRIPTION
This app is used as a canonical source for pixel events types. There are new events triggered by our store. This PR update those events types to match the ones that are available.