### PR TITLE
Replace cart with cartLoaded event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Replace handler of `vtex:cart` event to `vtex:cartLoaded`.
 
 ## [2.5.0] - 2020-09-14
 

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -218,7 +218,7 @@ export function handleEvents(e: PixelMessage) {
       return
     }
 
-    case 'vtex:cart': {
+    case 'vtex:cartLoaded': {
       const { orderForm } = e.data
 
       push({

--- a/react/typings/events.d.ts
+++ b/react/typings/events.d.ts
@@ -141,9 +141,9 @@ export interface ProductImpressionData extends EventData {
   list: string
 }
 
-export interface CartData extends EventData {
-  event: 'cart'
-  eventName: 'vtex:cart'
+export interface CartLoadedData extends EventData {
+  event: 'cartLoaded'
+  eventName: 'vtex:cartLoaded'
   orderForm: OrderForm
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Updates the `vtex:cart` event handler to handle the `vtex:cartLoaded` event instead.

#### What problem is this solving?

The `vtex:cart` event is triggered just after the cart page is first rendered, which may not have the orderForm loaded yet, but the `vtex:cartLoaded` is guaranteed to only fire _after_ the orderForm is successfully loaded in the page.

#### How should this be manually tested?

Access [this](https://lucas--checkoutio.myvtex.com/cart/add?sku=289) workspace, and check that the event in `window.dataLayer` contains the item in your cart.

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.