### PR TITLE
Add promoView and promotionClick events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Events `promoView` and `promotionClick`.
 
 ## [2.5.1] - 2020-09-15
 ### Changed

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -236,6 +236,34 @@ export function handleEvents(e: PixelMessage) {
       break
     }
 
+    case 'vtex:promoView': {
+      const { promotions } = e.data
+
+      push({
+        event: 'promoView',
+        ecommerce: {
+          promoView: {
+            promotions: promotions
+          }
+        }
+      })
+      break
+    }
+
+    case 'vtex:promotionClick': {
+      const { promotions } = e.data
+
+      push({
+        event: 'promotionClick',
+        ecommerce: {
+          promoClick: {
+            promotions: promotions
+          }
+        }
+      })
+      break
+    }
+
     default: {
       break
     }

--- a/react/typings/events.d.ts
+++ b/react/typings/events.d.ts
@@ -15,6 +15,8 @@ export interface PixelMessage extends MessageEvent {
     | UserData
     | CartIdData
     | CartData
+    | PromoViewData
+    | PromotionClickData
 }
 
 export interface EventData {
@@ -145,6 +147,25 @@ export interface CartLoadedData extends EventData {
   event: 'cartLoaded'
   eventName: 'vtex:cartLoaded'
   orderForm: OrderForm
+}
+
+export interface PromoViewData extends EventData {
+  event: 'promoView'
+  eventType: 'vtex:promoView'
+  promotions: Promotion[]
+}
+
+export interface PromotionClickData extends EventData {
+  event: 'promotionClick'
+  eventType: 'vtex:promotionClick'
+  promotions: Promotion[]
+}
+
+interface Promotion {
+  id?: string
+  name?: string
+  creative?: string
+  position?: string
 }
 
 interface CartItemAdditionalInfo {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Related to https://github.com/vtex-apps/store-image/pull/29

Send promotion impressions and clicks
Promotion View: https://developers.google.com/tag-manager/enhanced-ecommerce#promo-impressions
Promotion Click: https://developers.google.com/tag-manager/enhanced-ecommerce#promo-clicks

#### How should this be manually tested?

You can check this workspace:
https://promoview--storecomponents.myvtex.com/

Check the `dataLayer` variable

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/284515/98827086-352d3380-2415-11eb-8762-93e6ca49f6b7.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
