### PR TITLE
Add list property to productClick event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `list` property to `productClick`.
 
 ## [2.6.0] - 2020-12-01
 ### Added

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -66,6 +66,9 @@ export function handleEvents(e: PixelMessage) {
 
     case 'vtex:productClick': {
       const { productName, brand, categories, sku } = e.data.product
+      const list = e.data.list
+        ? { actionField: { list: e.data.list } }
+        : {}
 
       let price
 
@@ -79,6 +82,7 @@ export function handleEvents(e: PixelMessage) {
         event: 'productClick',
         ecommerce: {
           click: {
+            ...list,
             products: [
               {
                 brand,

--- a/react/typings/events.d.ts
+++ b/react/typings/events.d.ts
@@ -132,6 +132,7 @@ export interface ProductClickData extends EventData {
   event: 'productClick'
   eventName: 'vtex:productClick'
   product: ProductSummary
+  list?: string
 }
 
 export interface ProductImpressionData extends EventData {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Improve productClick analytics event.

#### How should this be manually tested?

https://summary--storecomponents.myvtex.com/

1. Open the store
2. Click on a product of the shelf
3. Check the dataLayer for the productClick event
4. Look for the list name info

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/284515/101527216-78bf8280-396c-11eb-9c7b-1f301bcc2454.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
