### PR TITLE
Fix price being sent as integer instead of float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Property `price` being sent as `integer` in `addToCart` event when using the block `add-to-cart-button`.
 
 ## [2.9.0] - 2021-01-18
 ### Added

--- a/react/modules/enhancedEcommerceEvents.ts
+++ b/react/modules/enhancedEcommerceEvents.ts
@@ -6,6 +6,7 @@ import {
   Impression,
   CartItem,
   AddToCartData,
+  RemoveToCartData,
 } from '../typings/events'
 import { AnalyticsEcommerceProduct } from '../typings/gtm'
 
@@ -107,18 +108,19 @@ export function sendEnhancedEcommerceEvents(e: PixelMessage) {
     }
 
     case 'vtex:removeFromCart': {
-      const { items } = e.data
+      const { items } = e.data as RemoveToCartData
 
       push({
         ecommerce: {
           currencyCode: e.data.currency,
           remove: {
-            products: items.map((sku: any) => ({
+            products: items.map(sku => ({
               brand: sku.brand,
               id: sku.skuId,
               category: sku.category,
               name: sku.name,
-              price: `${sku.price}`,
+              price:
+                sku.priceIsInt === true ? `${sku.price / 100}` : `${sku.price}`,
               quantity: sku.quantity,
               variant: sku.variant,
             })),

--- a/react/modules/enhancedEcommerceEvents.ts
+++ b/react/modules/enhancedEcommerceEvents.ts
@@ -5,6 +5,7 @@ import {
   ProductOrder,
   Impression,
   CartItem,
+  AddToCartData,
 } from '../typings/events'
 import { AnalyticsEcommerceProduct } from '../typings/gtm'
 
@@ -46,9 +47,7 @@ export function sendEnhancedEcommerceEvents(e: PixelMessage) {
 
     case 'vtex:productClick': {
       const { productName, brand, categories, sku } = e.data.product
-      const list = e.data.list
-        ? { actionField: { list: e.data.list } }
-        : {}
+      const list = e.data.list ? { actionField: { list: e.data.list } } : {}
 
       let price
 
@@ -83,17 +82,18 @@ export function sendEnhancedEcommerceEvents(e: PixelMessage) {
     }
 
     case 'vtex:addToCart': {
-      const { items } = e.data
+      const { items } = e.data as AddToCartData
 
       push({
         ecommerce: {
           add: {
-            products: items.map((sku: any) => ({
+            products: items.map(sku => ({
               brand: sku.brand,
               category: sku.category,
               id: sku.skuId,
               name: sku.name,
-              price: `${sku.price}`,
+              price:
+                sku.priceIsInt === true ? `${sku.price / 100}` : `${sku.price}`,
               quantity: sku.quantity,
               variant: sku.variant,
             })),
@@ -212,9 +212,9 @@ export function sendEnhancedEcommerceEvents(e: PixelMessage) {
         event: 'promoView',
         ecommerce: {
           promoView: {
-            promotions: promotions
-          }
-        }
+            promotions,
+          },
+        },
       })
       break
     }
@@ -226,9 +226,9 @@ export function sendEnhancedEcommerceEvents(e: PixelMessage) {
         event: 'promotionClick',
         ecommerce: {
           promoClick: {
-            promotions: promotions
-          }
-        }
+            promotions,
+          },
+        },
       })
       break
     }
@@ -238,7 +238,6 @@ export function sendEnhancedEcommerceEvents(e: PixelMessage) {
     }
   }
 }
-
 
 function getPurchaseObjectData(order: Order) {
   return {

--- a/react/typings/events.d.ts
+++ b/react/typings/events.d.ts
@@ -186,6 +186,7 @@ interface CartItem {
   name: string
   skuName: string
   price: number
+  priceIsInt?: boolean
   sellingPrice: number
   productId: string
   productRefId: string


### PR DESCRIPTION
#### What is the purpose of this pull request?

Send price property with the correct value when used with `add-to-cart-button`.

#### What problem is this solving?

https://breno--storecomponents.myvtex.com/

#### How should this be manually tested?

1. Open workspace
2. Add item to cart
3. Check global JS variable `dataLayer`
4. Look for the `addToCart` event
5. Check the `price` property

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/284515/111355856-89b41a00-8666-11eb-8ba7-c07b3aea3d93.png)


#### Related to / Depends on

Depends on 
https://github.com/vtex-apps/add-to-cart-button/pull/66
https://github.com/vtex-apps/minicart/pull/265