### PR TITLE
-- add pageCategory for contentGroup on Google Analytics

### DIFF
--- a/react/modules/extraEvents.ts
+++ b/react/modules/extraEvents.ts
@@ -8,6 +8,7 @@ export async function sendExtraEvents(e: PixelMessage) {
         event: 'pageView',
         location: e.data.pageUrl,
         page: e.data.pageUrl.replace(e.origin, ''),
+        pageCategory: e.data.routeId,
         referrer: e.data.referrer,
         ...(e.data.pageTitle && {
           title: e.data.pageTitle,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Implement content grouping within Google Analytics through `routeId` in the message layer that vtex provides.
<!--- Describe your changes in detail. -->

#### What problem is this solving?
In google analytics there is a [feature](https://support.google.com/analytics/answer/2853423) that automatically calculates metrics based on template names and not page views. From this implementation we would be able send this information with pageview hit of Google Anlaytics
<!--- What is the motivation and context for this change? -->

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
