### PR TITLE
fix: add originalLocation variable to dataLayer 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add originalLocation variable to dataLayer
 
 ## [3.0.0] - 2021-07-13
 ### Changed

--- a/pixel/head.html
+++ b/pixel/head.html
@@ -6,6 +6,12 @@
     } else {
       window.dataLayer = window.dataLayer || [];
       window.dataLayer.push({ 'gtm.blacklist': {{ blacklist }} });
+      window.dataLayer.push({
+        originalLocation: document.location.protocol + '//' +
+                          document.location.hostname +
+                          document.location.pathname +
+                          document.location.search
+      });
       // GTM script snippet. Taken from: https://developers.google.com/tag-manager/quickstart
       (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR adds the `originalLocation` variable to the dataLayer during initialization. That makes the campaign info, such as `utm_medium` and `utm_source`, persist during navigation after it's combined with some GTM container configuration.

#### What problem is this solving?

This PR hopefully solves a problem where the `google/cpc` campaign data would be lost after user navigation.

#### How should this be manually tested?

A bit tricky to go full circle on this, but for this PR purpose, just type `dataLayer` at the console and check if there's an object with an `originalLocation` property inside.

[Workspace](https://icaroprod--storecomponents.myvtex.com)
#### Screenshots or example usage

<img width="1185" alt="Screen Shot 2021-07-26 at 15 31 18" src="https://user-images.githubusercontent.com/8127610/127040213-a769dc70-f742-4da4-a8b9-b10358d38639.png">

### Related to

https://github.com/vtex-apps/google-tag-manager/pull/63 This is the fix for the 3.x version of the app. It's exactly the same code and effect.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
