### PR TITLE
Lazy load GTM pixel script via app settings (version 2.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Lazy load pixel script via app settings
 
 ## [2.9.3] - 2021-07-29
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "google-tag-manager",
   "vendor": "vtex",
-  "version": "2.10.0-beta.5",
+  "version": "2.10.0-beta.6",
   "title": "Google Tag Manager",
   "description": "Google Tag Manager",
   "mustUpdateAt": "2019-04-03",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "google-tag-manager",
   "vendor": "vtex",
-  "version": "2.10.0-beta.0",
+  "version": "2.10.0-beta.5",
   "title": "Google Tag Manager",
   "description": "Google Tag Manager",
   "mustUpdateAt": "2019-04-03",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "google-tag-manager",
   "vendor": "vtex",
-  "version": "2.9.3",
+  "version": "2.10.0-beta.0",
   "title": "Google Tag Manager",
   "description": "Google Tag Manager",
   "mustUpdateAt": "2019-04-03",

--- a/manifest.json
+++ b/manifest.json
@@ -45,6 +45,16 @@
         "title": "Allow Custom HTML tags",
         "description": "Beware that using Custom HTML tags can drastically impact the store's performance",
         "type": "boolean"
+      },
+      "experimentalLazyLoad": {
+        "title": "Lazy load Google Tag Manager Pixel",
+        "type": "string",
+        "description": "Lazy load Google Tag Manager Pixel",
+        "enum": [
+          "default",
+          "always",
+          "never"
+        ]
       }
     }
   },

--- a/pixel/head.html
+++ b/pixel/head.html
@@ -13,10 +13,33 @@
                           document.location.search
       });
       // GTM script snippet. Taken from: https://developers.google.com/tag-manager/quickstart
-      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      (function(w,d,s,l,i){
+        w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});
+
+        const isLazyLoad = "{{settings.experimentalLazyLoad}}" === 'true'
+
+        function appendScript() {
+          var f=d.getElementsByTagName(s)[0],
+          j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+          'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+        }
+
+        if (isLazyLoad) {
+          function lazyTimeout() {
+            setTimeout(appendScript, 5000)
+            window.removeEventListener('load', lazyTimeout)
+          }
+
+          if (document.readyState === 'complete') {
+            lazyTimeout()
+          } else {
+            window.addEventListener('load', lazyTimeout)
+          }
+
+          return
+        }
+
+        appendScript()
       })(window,document,'script','dataLayer',gtmId)
     }
   })()

--- a/pixel/head.html
+++ b/pixel/head.html
@@ -16,7 +16,7 @@
       (function(w,d,s,l,i){
         w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});
 
-        const isLazyLoad = "{{settings.experimentalLazyLoad}}" === 'true'
+        const isLazyLoad = "{{settings.experimentalLazyLoad}}" === "always"
 
         function appendScript() {
           var f=d.getElementsByTagName(s)[0],


### PR DESCRIPTION
#### What is the purpose of this pull request?
This PR adds a way to lazy load GTM pixel scripts via app settings

#### What problem is this solving?
Improve performance of the store

#### How should this be manually tested?
Run this command to test.
```sh
vtex settings set vtex.google-tag-manager experimentalLazyLoad true
```
#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [X] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
