### PR TITLE
Fix/original variables campaign persist

### DIFF
--- a/pixel/head.html
+++ b/pixel/head.html
@@ -6,12 +6,6 @@
     } else {
       window.dataLayer = window.dataLayer || [];
       window.dataLayer.push({ 'gtm.blacklist': {{ blacklist }} });
-      window.dataLayer.push({
-        originalLocation: document.location.protocol + '//' +
-                          document.location.hostname +
-                          document.location.pathname +
-                          document.location.search
-      });
       // GTM script snippet. Taken from: https://developers.google.com/tag-manager/quickstart
       (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -1,11 +1,14 @@
 import { canUseDOM } from 'vtex.render-runtime'
+
 import { sendEnhancedEcommerceEvents } from './modules/enhancedEcommerceEvents'
 import { sendExtraEvents } from './modules/extraEvents'
 import { sendLegacyEvents } from './modules/legacyEvents'
 import { PixelMessage } from './typings/events'
 
 // no-op for extension point
-export default function () { return null }
+export default function() {
+  return null
+}
 
 export function handleEvents(e: PixelMessage) {
   sendEnhancedEcommerceEvents(e)

--- a/react/modules/analytics/index.ts
+++ b/react/modules/analytics/index.ts
@@ -1,0 +1,49 @@
+import {
+  AnalyticsData,
+  AnalyticsDataWithOrigin,
+  currentDateInSeconds,
+  getAnalyticsFromStorage,
+  isStorageExpired,
+  renewExpirationDate,
+  saveAnalyticsOnStorage,
+  shouldInvalidateCurrentCampaign,
+} from './utils'
+
+export function createOrGetAnalyticsData(): AnalyticsDataWithOrigin {
+  let analyticsData = getAnalyticsData()
+  let origin: AnalyticsDataWithOrigin['origin'] = 'storage'
+
+  if (!analyticsData) {
+    analyticsData = createAnalyticsData()
+    origin = 'fresh'
+  }
+
+  saveAnalyticsOnStorage(analyticsData)
+
+  return { ...analyticsData, origin }
+}
+
+function getAnalyticsData(): AnalyticsData | null {
+  const analyticsFromStorage = getAnalyticsFromStorage()
+
+  if (
+    !analyticsFromStorage ||
+    isStorageExpired(analyticsFromStorage.expires, currentDateInSeconds()) ||
+    shouldInvalidateCurrentCampaign(window.location, document.referrer)
+  ) {
+    return null
+  }
+
+  return {
+    ...analyticsFromStorage,
+    expires: renewExpirationDate(),
+  }
+}
+
+function createAnalyticsData(): AnalyticsData {
+  return {
+    location: window.location.href,
+    referrer: document.referrer,
+    expires: renewExpirationDate(),
+  }
+}

--- a/react/modules/analytics/utils.ts
+++ b/react/modules/analytics/utils.ts
@@ -33,7 +33,7 @@ export function shouldInvalidateCurrentCampaign(
   const referrerURL = referrer ? new URL(referrer) : null
 
   // if user comes from a referring website
-  if (referrerURL && referrerURL.host !== location.host) {
+  if (referrerURL?.host !== location.host) {
     return true
   }
 
@@ -84,7 +84,7 @@ export function currentDateInSeconds() {
   return Math.floor(Date.now() / 1000)
 }
 
-export const THIRTY_MIN_IN_SECONDS = 1800
+export const THIRTY_MIN_IN_SECONDS = 30 * 60
 
 export function isStorageExpired(expiresIn: number, now: number) {
   return now - expiresIn > 0

--- a/react/modules/analytics/utils.ts
+++ b/react/modules/analytics/utils.ts
@@ -26,11 +26,6 @@ export const analyticsURLParams = [
   'utm_id',
 ] as const
 
-// Default referrer utm_medium attributed by GTM when there's no utm_medium and a user navigates from another website
-const REFERRER_UTM_MEDIUM = 'referral'
-
-const REFERRER_WWW_PREFIX = 'www.'
-
 export const keyValueToParam = (key: string, value: string) => `${key}=${value}`
 
 export function shouldInvalidateCurrentCampaign(
@@ -52,35 +47,6 @@ export function shouldInvalidateCurrentCampaign(
       locationParam.startsWith(`${campaignParam}=`)
     )
   })
-}
-
-export function getUTMWithReferral(
-  location: Location,
-  referrer: string | undefined
-) {
-  if (!referrer) {
-    return location.search
-  }
-
-  const referrerURL = new URL(referrer)
-
-  if (shouldInvalidateCurrentCampaign(location, referrer)) {
-    return location.search
-  }
-
-  // Mimics how GTM does it
-  const referrerUtmSource = referrerURL.hostname.replace(
-    REFERRER_WWW_PREFIX,
-    ''
-  )
-
-  const separator = location.search ? '&' : '?'
-
-  // Appends referral utm params to url
-  return `${location.search}${separator}${keyValueToParam(
-    UTM_SOURCE_PARAM,
-    referrerUtmSource
-  )}&${keyValueToParam(UTM_MEDIUM_PARAM, REFERRER_UTM_MEDIUM)}`
 }
 
 const STORAGE_KEY_ANALYTICS_DATA = 'analytics:session'

--- a/react/modules/analytics/utils.ts
+++ b/react/modules/analytics/utils.ts
@@ -1,0 +1,131 @@
+// Almost all of the logic of expiration and campaign invalidation is based on this official GA article https://support.google.com/analytics/answer/2731565
+
+export interface AnalyticsData {
+  location: string
+  referrer: string
+  expires: number
+}
+
+export interface AnalyticsDataWithOrigin extends AnalyticsData {
+  origin: 'storage' | 'fresh'
+}
+
+export const UTM_SOURCE_PARAM = 'utm_source'
+export const UTM_MEDIUM_PARAM = 'utm_medium'
+
+// All of these parameters trigger a new session storage of the url
+// This list was inspired by Simo Ahava's list used on his cookie implementation of this feature
+// https://www.simoahava.com/analytics/persist-campaign-data-landing-page/#setup-the-persist-campaign-data-tag
+export const analyticsURLParams = [
+  UTM_SOURCE_PARAM,
+  UTM_MEDIUM_PARAM,
+  'utm_campaign',
+  'gclid',
+  'utm_term',
+  'utm_content',
+  'utm_id',
+] as const
+
+// Default referrer utm_medium attributed by GTM when there's no utm_medium and a user navigates from another website
+const REFERRER_UTM_MEDIUM = 'referral'
+
+const REFERRER_WWW_PREFIX = 'www.'
+
+export const keyValueToParam = (key: string, value: string) => `${key}=${value}`
+
+export function shouldInvalidateCurrentCampaign(
+  location: Location,
+  referrer: string
+) {
+  const referrerURL = referrer ? new URL(referrer) : null
+
+  // if user comes from a referring website
+  if (referrerURL && referrerURL.host !== location.host) {
+    return true
+  }
+
+  // the slice removes the initial "?" character
+  const individualLocationParams = location.search.slice(1).split('&')
+
+  return individualLocationParams.some(locationParam => {
+    return analyticsURLParams.some(campaignParam =>
+      locationParam.startsWith(`${campaignParam}=`)
+    )
+  })
+}
+
+export function getUTMWithReferral(
+  location: Location,
+  referrer: string | undefined
+) {
+  if (!referrer) {
+    return location.search
+  }
+
+  const referrerURL = new URL(referrer)
+
+  if (shouldInvalidateCurrentCampaign(location, referrer)) {
+    return location.search
+  }
+
+  // Mimics how GTM does it
+  const referrerUtmSource = referrerURL.hostname.replace(
+    REFERRER_WWW_PREFIX,
+    ''
+  )
+
+  const separator = location.search ? '&' : '?'
+
+  // Appends referral utm params to url
+  return `${location.search}${separator}${keyValueToParam(
+    UTM_SOURCE_PARAM,
+    referrerUtmSource
+  )}&${keyValueToParam(UTM_MEDIUM_PARAM, REFERRER_UTM_MEDIUM)}`
+}
+
+const STORAGE_KEY_ANALYTICS_DATA = 'analytics:session'
+
+export function getAnalyticsFromStorage(): AnalyticsData | null {
+  let analyticsData = null
+
+  try {
+    const rawAnalyticsData = window.localStorage.getItem(
+      STORAGE_KEY_ANALYTICS_DATA
+    )
+
+    analyticsData = rawAnalyticsData ? JSON.parse(rawAnalyticsData) : null
+  } catch (e) {
+    console.error(
+      'Error while fetching original browser location from localStorage storage'
+    )
+  }
+
+  return analyticsData
+}
+
+export async function saveAnalyticsOnStorage(analyticsData: AnalyticsData) {
+  try {
+    window.localStorage.setItem(
+      STORAGE_KEY_ANALYTICS_DATA,
+      JSON.stringify(analyticsData)
+    )
+  } catch (e) {
+    console.error(
+      'Error while saving original browser location on localStorage storage'
+    )
+  }
+}
+
+export function currentDateInSeconds() {
+  return Math.floor(Date.now() / 1000)
+}
+
+export const THIRTY_MIN_IN_SECONDS = 1800
+
+export function isStorageExpired(expiresIn: number, now: number) {
+  return now - expiresIn > 0
+}
+
+export function renewExpirationDate() {
+  return currentDateInSeconds() + THIRTY_MIN_IN_SECONDS
+}

--- a/react/modules/analytics/utils.ts
+++ b/react/modules/analytics/utils.ts
@@ -26,8 +26,6 @@ export const analyticsURLParams = [
   'utm_id',
 ] as const
 
-export const keyValueToParam = (key: string, value: string) => `${key}=${value}`
-
 export function shouldInvalidateCurrentCampaign(
   location: Location,
   referrer: string

--- a/react/modules/analytics/utils.ts
+++ b/react/modules/analytics/utils.ts
@@ -33,7 +33,7 @@ export function shouldInvalidateCurrentCampaign(
   const referrerURL = referrer ? new URL(referrer) : null
 
   // if user comes from a referring website
-  if (referrerURL?.host !== location.host) {
+  if (referrerURL && referrerURL.host !== location.host) {
     return true
   }
 

--- a/react/modules/push.ts
+++ b/react/modules/push.ts
@@ -1,5 +1,23 @@
+import { createOrGetAnalyticsData } from './analytics'
+
 window.dataLayer = window.dataLayer || []
 
-export default function push(event: any) {
+export default function push(rawEvent: Record<string, unknown>) {
+  const {
+    location: originalLocation,
+    referrer: originalReferrer,
+    origin,
+  } = createOrGetAnalyticsData()
+
+  let event = rawEvent
+
+  if (window.dataLayer.length === 0 || origin === 'fresh') {
+    event = {
+      ...rawEvent,
+      originalLocation,
+      originalReferrer,
+    }
+  }
+
   window.dataLayer.push(event)
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR adds GA session manager to the GTM app. It now has the ability to create, get, update and invalidate a session that's saved on the local storage. It mimics [GA's behavior](https://support.google.com/analytics/answer/2731565#zippy=%2Cin-this-article) when dealing with expiration quotas (30 minutes).

Related to: https://github.com/vtex/vcs.checkout-ui/pull/1177

#### What problem is this solving?

This PR solves several issues with campaign persistence when users navigated through the page, which caused multiple sessions to be created. It also solves an issue where users coming from google with an implicit `utm_source` session due to the referrer would lost the campaign data when they entered the checkout page.

#### How should this be manually tested?
Go to this [Workspace](https://icarogtm--storecomponents.myvtex.com) and look for the Application tab on the developer tools and find the local storage entry `analytics:session` similar to the image below.

On the console tab, type `dataLayer` and check if the first event contains the `originalLocation` and the `originalReferrer` variables.

#### Screenshots or example usage

![Screen Shot 2021-10-28 at 14 55 03](https://user-images.githubusercontent.com/8127610/139313738-1f1114b2-9f3e-4bc7-8db7-28c832a40105.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
