### PR TITLE
Fixing first push detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- First event push is now detected correctly, considering that there may be GTM native events on the `dataLayer` array before the first push happens
 
 ## [3.1.0] - 2021-11-09
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Fixed
 - First event push is now detected correctly, considering that there may be GTM native events on the `dataLayer` array before the first push happens
+- Current campaign is no longer invalidated when the browser referrer matches the storage referrer
 
 ## [3.1.0] - 2021-11-09
 ### Added

--- a/react/modules/analytics/index.ts
+++ b/react/modules/analytics/index.ts
@@ -29,7 +29,11 @@ function getAnalyticsData(): AnalyticsData | null {
   if (
     !analyticsFromStorage ||
     isStorageExpired(analyticsFromStorage.expires, currentDateInSeconds()) ||
-    shouldInvalidateCurrentCampaign(window.location, document.referrer)
+    shouldInvalidateCurrentCampaign(
+      window.location,
+      document.referrer,
+      analyticsFromStorage.referrer
+    )
   ) {
     return null
   }

--- a/react/modules/analytics/utils.ts
+++ b/react/modules/analytics/utils.ts
@@ -28,12 +28,17 @@ export const analyticsURLParams = [
 
 export function shouldInvalidateCurrentCampaign(
   location: Location,
-  referrer: string
+  referrer: string,
+  storageReferrer: string
 ) {
   const referrerURL = referrer ? new URL(referrer) : null
 
   // if user comes from a referring website
-  if (referrerURL && referrerURL.host !== location.host) {
+  if (
+    referrerURL &&
+    referrer !== storageReferrer &&
+    referrerURL.host !== location.host
+  ) {
     return true
   }
 

--- a/react/modules/push.ts
+++ b/react/modules/push.ts
@@ -2,6 +2,8 @@ import { createOrGetAnalyticsData } from './analytics'
 
 window.dataLayer = window.dataLayer || []
 
+let isFirstPush = true
+
 export default function push(rawEvent: Record<string, unknown>) {
   const {
     location: originalLocation,
@@ -11,7 +13,9 @@ export default function push(rawEvent: Record<string, unknown>) {
 
   let event = rawEvent
 
-  if (window.dataLayer.length === 0 || origin === 'fresh') {
+  if (isFirstPush || origin === 'fresh') {
+    isFirstPush = false
+
     event = {
       ...rawEvent,
       originalLocation,


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR fixes `originalLocation` and `originalReferrer` variables not being added to the events sent to the `dataLayer` because the `dataLayer` already had native GTM events in there.

#### How should this be manually tested?

Type `dataLayer` into the console. Only the first event sent by the Google Tag Manager app (usually `pageView`) should have the variables mentioned above.

[Workspace](https://icarogtm--storecomponents.myvtex.com/)

#### Screenshots or example usage

![Screen Shot 2021-11-10 at 16 19 26](https://user-images.githubusercontent.com/8127610/141178877-cdec4339-7d0f-4292-b4fc-d3bc3eb2225d.png)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
