### PR TITLE
Removing SKU name from product name on orderPlaced events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Product names on orderPlaced events now no longer include SKU name at the end
 
 ## [3.1.2] - 2021-11-19
 ### Fixed

--- a/react/modules/enhancedEcommerceEvents.ts
+++ b/react/modules/enhancedEcommerceEvents.ts
@@ -298,12 +298,17 @@ function getPurchaseObjectData(order: Order) {
 }
 
 function getProductObjectData(product: ProductOrder) {
+  const productName = getProductNameWithoutVariant(
+    product.name,
+    product.skuName
+  )
+
   return {
     brand: product.brand,
     category: product.categoryTree?.join('/'),
     id: product.id, // Product id
     variant: product.sku, // SKU id
-    name: product.name, // Product name
+    name: productName, // Product name
     price: product.price,
     quantity: product.quantity,
     dimension1: product.productRefId ?? '',


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR changes the product name on orderPlaced events so that it doesn't include the SKU name.

#### What problem is this solving?

This PR solves an inconsistency among events. The orderPlaced event should behave as all other events do, and not include the SKU name on the product name. This PR makes the orderPlaced event compliant with this requirement.

#### How should this be manually tested?
[Workspace](https://icarogtm--storecomponents.myvtex.com)
#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
