### PR TITLE
feat: add encrypt user mail to userdata Datalayer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Added a custom field to "userData" dataLayer 
+
 ## [3.1.3] - 2021-12-28
 ### Fixed
 - Product names on orderPlaced events now no longer include SKU name at the end

--- a/react/modules/extraEvents.ts
+++ b/react/modules/extraEvents.ts
@@ -2,6 +2,15 @@ import push from './push'
 import { PixelMessage } from '../typings/events'
 
 export async function sendExtraEvents(e: PixelMessage) {
+
+  async function digestMessage(message:string) {
+    const msgUint8 = new TextEncoder().encode(message);                           
+    const hashBuffer = await crypto.subtle.digest('SHA-256', msgUint8);
+    const hashArray = Array.from(new Uint8Array(hashBuffer));
+    const hashHex = hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+    return hashHex;
+  }
+
   switch (e.data.eventName) {
     case 'vtex:pageView': {
       push({
@@ -20,6 +29,8 @@ export async function sendExtraEvents(e: PixelMessage) {
     case 'vtex:userData': {
       const { data } = e
 
+      const criptoID = await digestMessage(data.email)
+
       if (!data.isAuthenticated) {
         return
       }
@@ -27,6 +38,7 @@ export async function sendExtraEvents(e: PixelMessage) {
       push({
         event: 'userData',
         userId: data.id,
+        criptoID: criptoID 
       })
 
       break

--- a/react/modules/extraEvents.ts
+++ b/react/modules/extraEvents.ts
@@ -1,15 +1,16 @@
 import push from './push'
 import { PixelMessage } from '../typings/events'
 
-export async function sendExtraEvents(e: PixelMessage) {
 
-  async function digestMessage(message:string) {
-    const msgUint8 = new TextEncoder().encode(message);                           
-    const hashBuffer = await crypto.subtle.digest('SHA-256', msgUint8);
-    const hashArray = Array.from(new Uint8Array(hashBuffer));
-    const hashHex = hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
-    return hashHex;
-  }
+async function emailToHash(email:string) {
+  const msgUint8 = new TextEncoder().encode(email);                           
+  const hashBuffer = await crypto.subtle.digest('SHA-256', msgUint8);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  const hashHex = hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+  return hashHex;
+}
+
+export async function sendExtraEvents(e: PixelMessage) {
 
   switch (e.data.eventName) {
     case 'vtex:pageView': {
@@ -33,12 +34,12 @@ export async function sendExtraEvents(e: PixelMessage) {
         return
       }
 
-      const criptoID = data.email ? await digestMessage(data.email) : undefined
+      const emailHash = data.email ? await emailToHash(data.email) : undefined
 
       push({
         event: 'userData',
         userId: data.id,
-        criptoID: criptoID 
+        emailHash: emailHash 
       })
 
       break

--- a/react/modules/extraEvents.ts
+++ b/react/modules/extraEvents.ts
@@ -29,11 +29,11 @@ export async function sendExtraEvents(e: PixelMessage) {
     case 'vtex:userData': {
       const { data } = e
 
-      const criptoID = await digestMessage(data.email)
-
       if (!data.isAuthenticated) {
         return
       }
+
+      const criptoID = data.email ? await digestMessage(data.email) : undefined
 
       push({
         event: 'userData',


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add the user's encrypted email to the 'userData' data layer.

#### What problem is this solving?

We need to capture data for Google to increase conversions in Google campaigns. It's about optimized conversions. It is necessary to start receiving the email of the logged in user encrypted in SHA256, that is, an anonymized source data, with this, we will not have problems in terms of LGPD

#### How should this be manually tested?

1. Access Workspace;
2. Log in;
3. In the console, verify that when typing dataLayer, in the 'userData' layer, the 'cryptId' field is displayed, which refers to the user's encrypted email.

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/48537086/149036924-ec705d35-362e-4170-87ab-0615c4d56372.png)


#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [X] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
