### PR TITLE
Fixing orderPlaced event ecommerceV2 property so it matches the one in the checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed 
+- Added `ecommerceV2` property sent on the orderPlaced event to match the checkout dataLayer 
 
 ## [3.2.0] - 2022-01-26
 ### Added 

--- a/react/modules/enhancedEcommerceEvents.ts
+++ b/react/modules/enhancedEcommerceEvents.ts
@@ -15,7 +15,7 @@ import {
 import { AnalyticsEcommerceProduct } from '../typings/gtm'
 
 function getSeller(sellers: Seller[]) {
-  const defaultSeller = sellers.find((seller) => seller.sellerDefault)
+  const defaultSeller = sellers.find(seller => seller.sellerDefault)
 
   if (!defaultSeller) {
     return sellers[0]
@@ -40,6 +40,7 @@ export async function sendEnhancedEcommerceEvents(e: PixelMessage) {
 
       const productAvailableQuantity = getSeller(selectedSku.sellers)
         .commertialOffer.AvailableQuantity
+
       const isAvailable =
         productAvailableQuantity > 0 ? 'available' : 'unavailable'
 
@@ -146,7 +147,7 @@ export async function sendEnhancedEcommerceEvents(e: PixelMessage) {
       push({
         ecommerce: {
           add: {
-            products: items.map((item) => ({
+            products: items.map(item => ({
               brand: item.brand,
               category: item.category,
               id: item.productId,
@@ -177,7 +178,7 @@ export async function sendEnhancedEcommerceEvents(e: PixelMessage) {
         ecommerce: {
           currencyCode: e.data.currency,
           remove: {
-            products: items.map((item) => ({
+            products: items.map(item => ({
               brand: item.brand,
               category: item.category,
               id: item.productId,
@@ -216,7 +217,15 @@ export async function sendEnhancedEcommerceEvents(e: PixelMessage) {
         // @ts-ignore
         event: 'orderPlaced',
         ...order,
+        // The name ecommerceV2 was introduced as a fix, so it is possible that some clients
+        // were using this as it was called before (ecommerce). For that reason,
+        // it will also be sent as ecommerce to the dataLayer.
         ecommerce,
+        // This variable is called ecommerceV2 so it matches the variable name present on the checkout
+        // This way, users can have one single tag for checkout and orderPlaced events
+        ecommerceV2: {
+          ecommerce,
+        },
       })
 
       return


### PR DESCRIPTION
#### What is the purpose of this pull request?

Historically, users configure one single tag for checkout and orderplaced pages. We want to allow that on version 3.x still.

#### What problem is this solving?

The checkout uses the `ecommerceV2` variable to get the event data, and it should do the same thing on the orderplaced. They couldn't until today, because there was no variable called `ecommerceV2` on the orderPlaced event. 

#### How should this be manually tested?
On the orderplaced page, type `dataLayer` into the browser console and check if there's an ecommerceV2 property inside the orderPlaced event.

[Workspace](https://icarogtm--storecomponents.myvtex.com/)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
