### PR TITLE
Feat/merge UA events to GA4

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,9 +13,7 @@
     "support": {
       "url": "https://support.vtex.com/hc/requests"
     },
-    "availableCountries": [
-      "*"
-    ]
+    "availableCountries": ["*"]
   },
   "builders": {
     "react": "3.x",
@@ -44,6 +42,11 @@
       "allowCustomHtmlTags": {
         "title": "Allow Custom HTML tags",
         "description": "Beware that using Custom HTML tags can drastically impact the store's performance",
+        "type": "boolean"
+      },
+      "mergeUAEvents": {
+        "title": "Merge Universal Analytics and Google Analytics 4 Events",
+        "description": "When this setting is active, UA events will be merged to their equivalent on GA4",
         "type": "boolean"
       }
     }

--- a/pixel/head.html
+++ b/pixel/head.html
@@ -1,6 +1,13 @@
 <script>
   (function() {
     var gtmId = "{{settings.gtmId}}";
+    var mergeUAEventsValue = "{{settings.mergeUAEvents}}"
+    var mergeUAEvents = mergeUAEventsValue == 'true'
+
+    window.__gtm__ = {
+      mergeUAEvents
+    }
+    
     if (!gtmId) {
       console.error('Warning: No Google Tag Manager ID is defined. Please configure it in the apps admin.');
     } else {

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -1,0 +1,17 @@
+import { PixelMessage } from '../typings/events'
+import updateEcommerce from './updateEcommerce'
+
+export const shouldMergeUAEvents = () => Boolean(window?.__gtm__?.mergeUAEvents)
+
+export function viewItem(event: PixelMessage) {
+  if (!shouldMergeUAEvents()) return
+
+  const eventName = 'view_item'
+
+  const data = {
+    event: eventName,
+    ...event,
+  }
+
+  updateEcommerce(eventName, data)
+}

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -1,3 +1,6 @@
 interface Window extends Window {
   dataLayer: any[]
+  __gtm__: {
+    mergeUAEvents: string
+  }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

<!--- Describe your changes in detail. -->

Added setting into manifest to allow merge events, read value from window `__gtm__` and ga events module to read and update events based on the setting value

<!--- What is the motivation and context for this change? -->
Add support for GA4 since UA will be deprecated

#### How should this be manually tested?
Change the value on admin and in the store check the value on `window.__gtm__`

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [X] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
