### PR TITLE
feature/partytown: Added the partytown library to enable shopkeepers …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.3.2] - 2023-01-24
+
+### Added
+- Added the `partytown` library to enable shopkeepers to load third party scripts off the main thread.
+
 ## [3.3.1] - 2022-04-04
 
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -103,6 +103,24 @@ If you have any Google Analytics tags using the Google Analytics Settings variab
 Once you have set up the Google Analytics variables and tags, follow Google's official guide on [how to submit and publish your store’s container](https://support.google.com/tagmanager/answer/6107163).
 
 
+## How to run third party scripts off the main thread?
+
+To improve the performance of the sites we will work with the [Partytown](https://partytown.builder.io/) library.
+
+### What is [Partytown](https://partytown.builder.io/)? 
+
+Partytown is a lazy-loaded library to help relocate resource intensive scripts into a web worker, and off of the main thread. Its goal is to help speed up sites by dedicating the main thread to your code, and offloading third-party scripts to a web worker.
+
+Before running the GTM application outside of the main thread, it is necessary to install `vtex install vtex.partytown@0.x` in the environment where it is being developed or produced.
+Learn more at [VTEX Partytown](https://github.com/vtex-apps/partytown).
+
+### Enable secondary thread loading
+
+Once the partytown app is installed, simply navigate to `/admin/apps/vtex.google-tag-manager@version/setup/` and select `text/partytown`.
+
+![alt text](https://ibb.co/646qtpb)
+
+Now your 3rd party apps are loaded off the main thread and your site load time is much less.
 ## Restrictions
 
 In order to avoid performance problems and unforeseen behavior, our VTEX IO Google Tag Manager solution uses the native GTM **blacklist** feature. You can read more about this feature on the [Google Developer Guide](https://developers.google.com/tag-manager/web/restrict).

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
   "name": "google-tag-manager",
   "vendor": "vtex",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "title": "Google Tag Manager",
   "description": "Google Tag Manager",
-  "mustUpdateAt": "2019-04-03",
+  "mustUpdateAt": "2023-01-24",
   "scripts": {
     "postreleasy": "vtex publish --verbose"
   },
@@ -40,6 +40,15 @@
         "title": "Google Tag Manager",
         "description": "Enter the ID (GTM-XXXX) from your Google Tag Manager",
         "type": "string"
+      },
+      "typeScript": {
+        "title": "Script attribute type",
+        "description": "Define whether the type attribute execute script on a secondary thread or not.",
+        "default": "text/javascript",
+        "enum": [
+          "javascript",
+          "partytown"
+        ]
       },
       "allowCustomHtmlTags": {
         "title": "Allow Custom HTML tags",

--- a/manifest.json
+++ b/manifest.json
@@ -44,7 +44,7 @@
       "typeScript": {
         "title": "Script attribute type",
         "description": "Define whether the type attribute execute script on a secondary thread or not.",
-        "default": "text/javascript",
+        "default": "javascript",
         "enum": [
           "javascript",
           "partytown"

--- a/pixel/head.html
+++ b/pixel/head.html
@@ -10,9 +10,17 @@
       // GTM script snippet. Taken from: https://developers.google.com/tag-manager/quickstart
       (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.type='text/'+typeScript;j.async=true;j.src=
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.type='text/' + validType();j.async=true;j.src=
       'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
       })(window,document,'script','dataLayer',gtmId)
     }
   })()
+
+  function validType() {
+    const href = window.location.search
+    const [, query] = href.split('?')
+    const searchParams = new URLSearchParams(query)
+
+    return !!searchParams.get('gtm_debug') ? 'javascript' : typeScript
+  }
 </script>

--- a/pixel/head.html
+++ b/pixel/head.html
@@ -1,6 +1,7 @@
 <script>
   (function() {
     var gtmId = "{{settings.gtmId}}";
+    var typeScript = "{{settings.typeScript}}"
     if (!gtmId) {
       console.error('Warning: No Google Tag Manager ID is defined. Please configure it in the apps admin.');
     } else {
@@ -9,7 +10,7 @@
       // GTM script snippet. Taken from: https://developers.google.com/tag-manager/quickstart
       (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.type='text/'+typeScript;j.async=true;j.src=
       'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
       })(window,document,'script','dataLayer',gtmId)
     }


### PR DESCRIPTION
#### What is the purpose of this pull request?
The main objective of this request is to enable shopkeepers to load third-party scripts outside the main thread with the help of the partytown library and the vtex application.

#### What problem is this solving?
Page loading time, considering core web vitals metrics.

#### How should this be manually tested?
Run the app in any development workspace, configure the google tag manager identifier, select partytown and save.
Just go to the website and make sure the type is text/partytown and then perform load tests.

#### Screenshots or example usage
![Captura de Tela 2023-01-24 às 17 43 58](https://user-images.githubusercontent.com/32168339/214406946-98c5ac16-6625-4759-a3f4-d25c3e1d1cbe.png)
![Captura de Tela 2023-01-24 às 17 44 07](https://user-images.githubusercontent.com/32168339/214406978-a3a1e52b-e1ae-47ad-bc11-35dea6fb5e0b.png)

![Captura de Tela 2023-01-24 às 17 37 45](https://user-images.githubusercontent.com/32168339/214404688-a573fca1-368b-4982-a175-300f9d2b5d9b.png)

#### Types of changes
* [x] New feature (a non-breaking change which adds functionality)

**Observation**:
In tests carried out, an evolution of 20 points of performance and improvement in fcp, tti, tbt and lcp was noticed.