### PR TITLE
Sends GA4 `select_promotion`

### DIFF
--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -3,6 +3,9 @@ import productDetails from '../__mocks__/productDetail'
 import productClick from '../__mocks__/productClick'
 import { handleEvents } from '../index'
 import updateEcommerce from '../modules/updateEcommerce'
+import shouldMergeUAEvents from '../modules/utils/shouldMergeUAEvents'
+
+jest.mock('../modules/utils/shouldMergeUAEvents')
 
 jest.mock('../modules/updateEcommerce', () => jest.fn())
 
@@ -111,5 +114,15 @@ test('productClick', () => {
         ],
       },
     },
+  })
+})
+
+describe('GA4 events', () => {
+  const mergeUAEvents = true
+  const mockedShouldMergeUAEvents = shouldMergeUAEvents as jest.Mock
+
+  beforeEach(() => {
+    mockedShouldMergeUAEvents.mockReset()
+    mockedShouldMergeUAEvents.mockReturnValue(mergeUAEvents)
   })
 })

--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -3,6 +3,7 @@ import productDetails from '../__mocks__/productDetail'
 import productClick from '../__mocks__/productClick'
 import { handleEvents } from '../index'
 import updateEcommerce from '../modules/updateEcommerce'
+import { Promotion, PromotionClickData } from '../typings/events'
 import shouldMergeUAEvents from '../modules/utils/shouldMergeUAEvents'
 
 jest.mock('../modules/utils/shouldMergeUAEvents')
@@ -124,5 +125,35 @@ describe('GA4 events', () => {
   beforeEach(() => {
     mockedShouldMergeUAEvents.mockReset()
     mockedShouldMergeUAEvents.mockReturnValue(mergeUAEvents)
+  })
+
+  describe('select_promotion', () => {
+    it('sends an event that signifies a promotion was selected from a list', () => {
+      const promotion: Promotion = {
+        id: 'P_12345',
+        name: 'Summer Sale',
+        creative: 'Summer Banner',
+        position: 'featured_app_1',
+      }
+
+      const data: PromotionClickData = {
+        currency: 'USD',
+        event: 'promotionClick',
+        eventName: 'vtex:promotionClick',
+        eventType: 'vtex:promotionClick',
+        promotions: [promotion],
+      }
+
+      const message = new MessageEvent('message', { data })
+
+      handleEvents(message)
+
+      expect(mockedUpdate).toHaveBeenCalledWith('select_promotion', {
+        creative_name: 'Summer Banner',
+        creative_slot: 'featured_app_1',
+        promotion_id: 'P_12345',
+        promotion_name: 'Summer Sale',
+      })
+    })
   })
 })

--- a/react/modules/enhancedEcommerceEvents.ts
+++ b/react/modules/enhancedEcommerceEvents.ts
@@ -12,7 +12,7 @@ import {
   ProductViewReferenceId,
 } from '../typings/events'
 import { AnalyticsEcommerceProduct } from '../typings/gtm'
-import { selectItem, viewItem, viewItemList } from './gaEvents'
+import { selectItem, selectPromotion, viewItem, viewItemList } from './gaEvents'
 import { getCategory, getSeller } from './utils'
 
 const defaultReference = { Value: '' }
@@ -300,6 +300,7 @@ export async function sendEnhancedEcommerceEvents(e: PixelMessage) {
         },
       }
 
+      selectPromotion(e.data)
       updateEcommerce('promotionClick', data)
 
       break

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -8,8 +8,7 @@ import {
   getImpressions,
   getDiscount,
 } from './utils'
-
-export const shouldMergeUAEvents = () => Boolean(window?.__gtm__?.mergeUAEvents)
+import shouldMergeUAEvents from './utils/shouldMergeUAEvents'
 
 export function viewItem(eventData: PixelMessage['data']) {
   if (!shouldMergeUAEvents()) return

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -102,3 +102,19 @@ export function selectItem(eventData: PixelMessage['data']) {
 
   updateEcommerce(eventName, data)
 }
+
+export function selectPromotion(eventData: PixelMessage['data']) {
+  if (!shouldMergeUAEvents()) return
+
+  const eventName = 'select_promotion'
+  const [promotion] = eventData.promotions
+
+  const data = {
+    creative_name: promotion.creative,
+    creative_slot: promotion.position,
+    promotion_id: promotion.id,
+    promotion_name: promotion.name,
+  }
+
+  updateEcommerce(eventName, data)
+}

--- a/react/modules/utils/shouldMergeUAEvents.ts
+++ b/react/modules/utils/shouldMergeUAEvents.ts
@@ -1,0 +1,3 @@
+export default function shouldMergeUAEvents() {
+  return Boolean(window?.__gtm__?.mergeUAEvents)
+}


### PR DESCRIPTION
#### What problem is this solving?

It sends the [GA4 `select_promotion`](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?hl=en&client_type=gtag#select_promotion) event when `vtex:promotionClick` is received. 

https://developers.google.com/analytics/devguides/collection/ga4/reference/events?hl=en&client_type=gtag#select_promotion|
-|
![CleanShot 2023-01-30 at 09 34 15](https://user-images.githubusercontent.com/381395/215479682-9e9a319f-79f0-43e0-a2c3-2e0a97872242.png)|

#### How should this be manually tested?

A new test has been added and can be run with `yarn test`.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
