### PR TITLE
Send GA4 view_promotion event

### DIFF
--- a/react/__mocks__/viewPromotion.ts
+++ b/react/__mocks__/viewPromotion.ts
@@ -1,105 +1,31 @@
-import { PromoViewData } from '../typings/events'
+import { Promotion, PromoViewData } from '../typings/events'
 
 const eventType = 'vtex:promoView'
 const eventName = 'vtex:promoView'
 const event = 'promoView'
 
-const list = 'Shelf'
-
-const position = 1
-
-const promotionId = 'P_12345'
-const promotionName = 'Summer Sale'
-const promotionCreativeName = 'Summer Banner'
-const promotionCreativeSlot = 'featured_app_1'
-const promotion = {
-  id: promotionId,
-  name: promotionName,
-  creative: promotionCreativeName,
-  position: promotionCreativeSlot,
-}
-
-const viewPromotion: PromoViewData = {
-  currency: 'USD',
-  eventType,
-  eventName,
-  event,
-  list,
+export function buildViewPromotionData({
+  id,
+  name,
+  creative,
   position,
-  promotions: [promotion],
-  product: {
-    productId: '16',
-    productName: 'Classic Shoes Top',
-    productReference: '12531',
-    categories: ['/Apparel & Accessories/Shoes/', '/Apparel & Accessories/'],
-    linkText: 'classic-shoes',
-    brand: 'Mizuno',
-    brandId: '2000010',
-    items: [
-      {
-        ean: '80098',
-        name: 'Classic Pink',
-        itemId: '35',
-        referenceId: {
-          Key: 'RefId',
-          Value: '12531',
-        },
-        seller: {
-          sellerId: '1',
-          sellerDefault: true,
-          commertialOffer: {
-            PriceWithoutDiscount: 38.9,
-            AvailableQuantity: 2000000,
-            Price: 38.9,
-            ListPrice: 38.9,
-          },
-        },
-        sellers: [
-          {
-            sellerId: '1',
-            sellerDefault: true,
-            commertialOffer: {
-              PriceWithoutDiscount: 38.9,
-              AvailableQuantity: 2000000,
-              Price: 38.9,
-              ListPrice: 38.9,
-            },
-          },
-        ],
-      },
-    ],
-    sku: {
-      ean: '80098',
-      name: 'Classic Pink',
-      itemId: '35',
-      referenceId: {
-        Key: 'RefId',
-        Value: '12531',
-      },
-      sellers: [
-        {
-          sellerId: '1',
-          sellerDefault: true,
-          commertialOffer: {
-            PriceWithoutDiscount: 38.9,
-            AvailableQuantity: 2000000,
-            Price: 38.9,
-            ListPrice: 38.9,
-          },
-        },
-      ],
-      seller: {
-        sellerId: '1',
-        sellerDefault: true,
-        commertialOffer: {
-          PriceWithoutDiscount: 38.9,
-          AvailableQuantity: 2000000,
-          Price: 38.9,
-          ListPrice: 38.9,
-        },
-      },
-    },
-  },
-}
+  products,
+}: Promotion): PromoViewData {
+  const promotion = {
+    id,
+    name,
+    creative,
+    position,
+    products,
+  }
 
-export default viewPromotion
+  const viewPromotion: PromoViewData = {
+    currency: 'USD',
+    event,
+    eventName,
+    eventType,
+    promotions: [promotion],
+  }
+
+  return viewPromotion
+}

--- a/react/__mocks__/viewPromotion.ts
+++ b/react/__mocks__/viewPromotion.ts
@@ -1,0 +1,105 @@
+import { PromoViewData } from '../typings/events'
+
+const eventType = 'vtex:promoView'
+const eventName = 'vtex:promoView'
+const event = 'promoView'
+
+const list = 'Shelf'
+
+const position = 1
+
+const promotionId = 'P_12345'
+const promotionName = 'Summer Sale'
+const promotionCreativeName = 'Summer Banner'
+const promotionCreativeSlot = 'featured_app_1'
+const promotion = {
+  id: promotionId,
+  name: promotionName,
+  creative: promotionCreativeName,
+  position: promotionCreativeSlot,
+}
+
+const viewPromotion: PromoViewData = {
+  currency: 'USD',
+  eventType,
+  eventName,
+  event,
+  list,
+  position,
+  promotions: [promotion],
+  product: {
+    productId: '16',
+    productName: 'Classic Shoes Top',
+    productReference: '12531',
+    categories: ['/Apparel & Accessories/Shoes/', '/Apparel & Accessories/'],
+    linkText: 'classic-shoes',
+    brand: 'Mizuno',
+    brandId: '2000010',
+    items: [
+      {
+        ean: '80098',
+        name: 'Classic Pink',
+        itemId: '35',
+        referenceId: {
+          Key: 'RefId',
+          Value: '12531',
+        },
+        seller: {
+          sellerId: '1',
+          sellerDefault: true,
+          commertialOffer: {
+            PriceWithoutDiscount: 38.9,
+            AvailableQuantity: 2000000,
+            Price: 38.9,
+            ListPrice: 38.9,
+          },
+        },
+        sellers: [
+          {
+            sellerId: '1',
+            sellerDefault: true,
+            commertialOffer: {
+              PriceWithoutDiscount: 38.9,
+              AvailableQuantity: 2000000,
+              Price: 38.9,
+              ListPrice: 38.9,
+            },
+          },
+        ],
+      },
+    ],
+    sku: {
+      ean: '80098',
+      name: 'Classic Pink',
+      itemId: '35',
+      referenceId: {
+        Key: 'RefId',
+        Value: '12531',
+      },
+      sellers: [
+        {
+          sellerId: '1',
+          sellerDefault: true,
+          commertialOffer: {
+            PriceWithoutDiscount: 38.9,
+            AvailableQuantity: 2000000,
+            Price: 38.9,
+            ListPrice: 38.9,
+          },
+        },
+      ],
+      seller: {
+        sellerId: '1',
+        sellerDefault: true,
+        commertialOffer: {
+          PriceWithoutDiscount: 38.9,
+          AvailableQuantity: 2000000,
+          Price: 38.9,
+          ListPrice: 38.9,
+        },
+      },
+    },
+  },
+}
+
+export default viewPromotion

--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -1,6 +1,7 @@
 import productImpressionData from '../__mocks__/productImpression'
 import productDetails from '../__mocks__/productDetail'
 import productClick from '../__mocks__/productClick'
+import viewPromotionData from '../__mocks__/viewPromotion'
 import { handleEvents } from '../index'
 import updateEcommerce from '../modules/updateEcommerce'
 import { Promotion, PromotionClickData } from '../typings/events'
@@ -153,6 +154,35 @@ describe('GA4 events', () => {
         creative_slot: 'featured_app_1',
         promotion_id: 'P_12345',
         promotion_name: 'Summer Sale',
+      })
+    })
+  })
+
+  describe('view_promotion', () => {
+    it('sends an event that signifies a promotion was viewed from a list', () => {
+      const message = new MessageEvent('message', { data: viewPromotionData })
+
+      handleEvents(message)
+
+      expect(mockedUpdate).toHaveBeenCalledWith('view_promotion', {
+        creative_name: 'Summer Banner',
+        creative_slot: 'featured_app_1',
+        promotion_id: 'P_12345',
+        promotion_name: 'Summer Sale',
+        items: [
+          {
+            item_id: '16',
+            item_name: 'Classic Shoes Top',
+            discount: 0,
+            index: 1,
+            item_brand: 'Mizuno',
+            item_category: 'Apparel & Accessories',
+            item_category2: 'Shoes',
+            item_list_name: 'Shelf',
+            item_variant: 'Classic Pink',
+            quantity: 2000000,
+          },
+        ],
       })
     })
   })

--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -306,24 +306,26 @@ describe('GA4 events', () => {
       handleEvents(message)
 
       expect(mockedUpdate).toHaveBeenCalledWith('view_promotion', {
-        creative_name: 'Summer Banner',
-        creative_slot: 'featured_app_1',
-        promotion_id: 'P_12345',
-        promotion_name: 'Summer Sale',
-        items: [
-          {
-            item_id: '16',
-            item_name: 'Classic Shoes Top',
-            discount: 0,
-            index: 1,
-            item_brand: 'Mizuno',
-            item_category: 'Apparel & Accessories',
-            item_category2: 'Shoes',
-            item_list_name: 'Shelf',
-            item_variant: 'Classic Pink',
-            quantity: 2000000,
-          },
-        ],
+        ecommerce: {
+          creative_name: 'Summer Banner',
+          creative_slot: 'featured_app_1',
+          promotion_id: 'P_12345',
+          promotion_name: 'Summer Sale',
+          items: [
+            {
+              item_id: '16',
+              item_name: 'Classic Shoes Top',
+              discount: 0,
+              index: 1,
+              item_brand: 'Mizuno',
+              item_category: 'Apparel & Accessories',
+              item_category2: 'Shoes',
+              item_list_name: 'Shelf',
+              item_variant: 'Classic Pink',
+              quantity: 2000000,
+            },
+          ],
+        },
       })
     })
   })

--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -1,7 +1,7 @@
 import productImpressionData from '../__mocks__/productImpression'
 import productDetails from '../__mocks__/productDetail'
 import productClick from '../__mocks__/productClick'
-import viewPromotionData from '../__mocks__/viewPromotion'
+import { buildViewPromotionData } from '../__mocks__/viewPromotion'
 import { handleEvents } from '../index'
 import updateEcommerce from '../modules/updateEcommerce'
 import {
@@ -387,7 +387,24 @@ describe('GA4 events', () => {
 
   describe('view_promotion', () => {
     it('sends an event that signifies a promotion was viewed from a list', () => {
-      const message = new MessageEvent('message', { data: viewPromotionData })
+      const data = buildViewPromotionData({
+        id: 'P_12345',
+        name: 'Summer Sale',
+        creative: 'Summer Banner',
+        position: 'featured_app_1',
+        products: [
+          {
+            productId: 'SKU_20',
+            productName: 'Tea Leaves',
+          },
+          {
+            productId: 'SKU_30',
+            productName: 'Coffee Beans',
+          },
+        ],
+      })
+
+      const message = new MessageEvent('message', { data })
 
       handleEvents(message)
 
@@ -399,16 +416,12 @@ describe('GA4 events', () => {
           promotion_name: 'Summer Sale',
           items: [
             {
-              item_id: '16',
-              item_name: 'Classic Shoes Top',
-              discount: 0,
-              index: 1,
-              item_brand: 'Mizuno',
-              item_category: 'Apparel & Accessories',
-              item_category2: 'Shoes',
-              item_list_name: 'Shelf',
-              item_variant: 'Classic Pink',
-              quantity: 2000000,
+              item_id: 'SKU_20',
+              item_name: 'Tea Leaves',
+            },
+            {
+              item_id: 'SKU_30',
+              item_name: 'Coffee Beans',
             },
           ],
         },

--- a/react/modules/enhancedEcommerceEvents.ts
+++ b/react/modules/enhancedEcommerceEvents.ts
@@ -10,9 +10,16 @@ import {
   ProductViewData,
   ProductClickData,
   ProductViewReferenceId,
+  PromoViewData,
 } from '../typings/events'
 import { AnalyticsEcommerceProduct } from '../typings/gtm'
-import { selectItem, selectPromotion, viewItem, viewItemList } from './gaEvents'
+import {
+  selectItem,
+  selectPromotion,
+  viewItem,
+  viewItemList,
+  viewPromotion,
+} from './gaEvents'
 import { getCategory, getSeller } from './utils'
 
 const defaultReference = { Value: '' }
@@ -272,7 +279,7 @@ export async function sendEnhancedEcommerceEvents(e: PixelMessage) {
     }
 
     case 'vtex:promoView': {
-      const { promotions } = e.data
+      const { promotions } = e.data as PromoViewData
 
       const data = {
         event: 'promoView',
@@ -283,6 +290,7 @@ export async function sendEnhancedEcommerceEvents(e: PixelMessage) {
         },
       }
 
+      viewPromotion(e.data)
       updateEcommerce('promoView', data)
 
       break

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -1,4 +1,4 @@
-import { PixelMessage } from '../typings/events'
+import { PixelMessage, PromoViewData } from '../typings/events'
 import updateEcommerce from './updateEcommerce'
 import {
   getPrice,
@@ -114,6 +114,50 @@ export function selectPromotion(eventData: PixelMessage['data']) {
     creative_slot: promotion.position,
     promotion_id: promotion.id,
     promotion_name: promotion.name,
+  }
+
+  updateEcommerce(eventName, data)
+}
+
+export function viewPromotion(eventData: PromoViewData) {
+  if (!shouldMergeUAEvents()) return
+
+  const eventName = 'view_promotion'
+
+  const {
+    promotions: [promotion],
+  } = eventData
+
+  let item = {}
+  const { product, list, position } = eventData
+
+  if (product) {
+    const { sku, productName, productId, categories, brand } = product
+    const { name: variant } = sku
+    const seller = getSeller(sku.sellers)
+    const categoriesHierarchy = getCategoriesWithHierarchy(categories)
+    const discount = getDiscount(seller)
+    const quantity = getQuantity(seller)
+
+    item = {
+      item_id: productId,
+      item_name: productName,
+      item_list_name: list,
+      item_brand: brand,
+      item_variant: variant,
+      index: position,
+      discount,
+      quantity,
+      ...categoriesHierarchy,
+    }
+  }
+
+  const data = {
+    creative_name: promotion.creative,
+    creative_slot: promotion.position,
+    promotion_id: promotion.id,
+    promotion_name: promotion.name,
+    items: [item],
   }
 
   updateEcommerce(eventName, data)

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -167,7 +167,7 @@ export function viewPromotion(eventData: PromoViewData) {
     items: [item],
   }
 
-  updateEcommerce(eventName, data)
+  updateEcommerce(eventName, { ecommerce: data })
 }
 
 export function addToCart(eventData: AddToCartData) {

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -135,39 +135,24 @@ export function viewPromotion(eventData: PromoViewData) {
   const eventName = 'view_promotion'
 
   const {
-    promotions: [promotion],
+    promotions: [{ creative, position, id, name, products }],
   } = eventData
 
-  let item = {}
-  const { product, list, position } = eventData
+  let items: Array<{ item_id: string; item_name: string }> = []
 
-  if (product) {
-    const { sku, productName, productId, categories, brand } = product
-    const { name: variant } = sku
-    const seller = getSeller(sku.sellers)
-    const categoriesHierarchy = getCategoriesWithHierarchy(categories)
-    const discount = getDiscount(seller)
-    const quantity = getQuantity(seller)
-
-    item = {
-      item_id: productId,
-      item_name: productName,
-      item_list_name: list,
-      item_brand: brand,
-      item_variant: variant,
-      index: position,
-      discount,
-      quantity,
-      ...categoriesHierarchy,
-    }
+  if (products?.length) {
+    items = products.map(product => ({
+      item_id: product.productId,
+      item_name: product.productName,
+    }))
   }
 
   const data = {
-    creative_name: promotion.creative,
-    creative_slot: promotion.position,
-    promotion_id: promotion.id,
-    promotion_name: promotion.name,
-    items: [item],
+    creative_name: creative,
+    creative_slot: position,
+    promotion_id: id,
+    promotion_name: name,
+    items,
   }
 
   updateEcommerce(eventName, { ecommerce: data })

--- a/react/typings/events.d.ts
+++ b/react/typings/events.d.ts
@@ -156,6 +156,9 @@ export interface PromoViewData extends EventData {
   event: 'promoView'
   eventType: 'vtex:promoView'
   promotions: Promotion[]
+  product?: ProductSummary
+  list?: string
+  position?: number
 }
 
 export interface PromotionClickData extends EventData {

--- a/react/typings/events.d.ts
+++ b/react/typings/events.d.ts
@@ -204,12 +204,6 @@ interface Totalizer {
   value: number
 }
 
-interface Seller {
-  id: string
-  name: string
-  logo: string
-}
-
 interface ClientProfileData {
   email: string
   firstName: string

--- a/react/typings/events.d.ts
+++ b/react/typings/events.d.ts
@@ -156,9 +156,6 @@ export interface PromoViewData extends EventData {
   event: 'promoView'
   eventType: 'vtex:promoView'
   promotions: Promotion[]
-  product?: ProductSummary
-  list?: string
-  position?: number
 }
 
 export interface PromotionClickData extends EventData {
@@ -167,11 +164,14 @@ export interface PromotionClickData extends EventData {
   promotions: Promotion[]
 }
 
+type PromotionProduct = Pick<ProductSummary, 'productId' | 'productName'>
+
 interface Promotion {
   id?: string
   name?: string
   creative?: string
   position?: string
+  products?: PromotionProduct[]
 }
 
 interface CartItemAdditionalInfo {


### PR DESCRIPTION
#### What problem is this solving?

Push the GA4's [`view_promotion`](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?hl=en&client_type=gtag#view_promotion) event when `vtex:promoView` is triggered.

#### How to test?

1. Visit https://filipelimaxga4viewpromo--storecomponents.myvtex.com/.
2. Click the right arrow button to see the next gallery image.
3. Check the `dataLayer` variable in the web console to ensure the `view_promotion` was fired.
![CleanShot 2023-02-27 at 10 53 44](https://user-images.githubusercontent.com/381395/221582147-f06fd60f-de92-45c7-b97f-8a045bb61a34.png)