### PR TITLE
feat: Adds `add_to_cart` GA4 event

### DIFF
--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -160,7 +160,9 @@ describe('GA4 events', () => {
         promotion_name: 'Summer Sale',
       })
     })
+  })
 
+  describe('add_to_cart', () => {
     it('sends an event that signifies an item being added to the cart', () => {
       type CartItemMockType = Pick<
         CartItem,
@@ -192,7 +194,7 @@ describe('GA4 events', () => {
         name: 'Top Wood 2',
         skuName: 'top_wood_300',
         price: 150.9,
-        category: 'Home & Decor',
+        category: 'Home & Decor/Tables',
         quantity: 1,
       }
 
@@ -226,6 +228,7 @@ describe('GA4 events', () => {
             item_name: 'Top Wood 2',
             item_variant: '2000305',
             item_category: 'Home & Decor',
+            item_category2: 'Tables',
             quantity: 1,
             price: 150.9,
           },

--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -3,7 +3,12 @@ import productDetails from '../__mocks__/productDetail'
 import productClick from '../__mocks__/productClick'
 import { handleEvents } from '../index'
 import updateEcommerce from '../modules/updateEcommerce'
-import { Promotion, PromotionClickData } from '../typings/events'
+import {
+  Promotion,
+  PromotionClickData,
+  AddToCartData,
+  CartItem,
+} from '../typings/events'
 import shouldMergeUAEvents from '../modules/utils/shouldMergeUAEvents'
 
 jest.mock('../modules/utils/shouldMergeUAEvents')
@@ -153,6 +158,58 @@ describe('GA4 events', () => {
         creative_slot: 'featured_app_1',
         promotion_id: 'P_12345',
         promotion_name: 'Summer Sale',
+      })
+    })
+
+    it('sends an event that signifies an item being added to the cart', () => {
+      type CartItemMockType = Pick<
+        CartItem,
+        | 'name'
+        | 'brand'
+        | 'price'
+        | 'skuId'
+        | 'skuName'
+        | 'quantity'
+        | 'category'
+        | 'productId'
+      >
+
+      const cartItem: CartItemMockType = {
+        productId: '200000202',
+        skuId: '2000304',
+        brand: 'Sony',
+        name: 'Top Wood',
+        skuName: 'top_wood_200',
+        price: 197.99,
+        category: 'Home & Decor',
+        quantity: 1,
+      }
+
+      const data: AddToCartData = {
+        currency: 'USD',
+        event: 'addToCart',
+        eventName: 'vtex:addToCart',
+        items: [cartItem as CartItem],
+      }
+
+      const message = new MessageEvent('message', { data })
+
+      handleEvents(message)
+
+      expect(mockedUpdate).toHaveBeenCalledWith('add_to_cart', {
+        currency: 'USD',
+        value: 197.99,
+        items: [
+          {
+            item_id: '200000202',
+            item_brand: 'Sony',
+            item_name: 'Top Wood',
+            item_variant: '2000304',
+            item_category: 'Home & Decor',
+            quantity: 1,
+            price: 197.99,
+          },
+        ],
       })
     })
   })

--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -174,7 +174,7 @@ describe('GA4 events', () => {
         | 'productId'
       >
 
-      const cartItem: CartItemMockType = {
+      const cartItem1: CartItemMockType = {
         productId: '200000202',
         skuId: '2000304',
         brand: 'Sony',
@@ -185,11 +185,22 @@ describe('GA4 events', () => {
         quantity: 1,
       }
 
+      const cartItem2: CartItemMockType = {
+        productId: '200000203',
+        skuId: '2000305',
+        brand: 'Sony',
+        name: 'Top Wood 2',
+        skuName: 'top_wood_300',
+        price: 150.9,
+        category: 'Home & Decor',
+        quantity: 1,
+      }
+
       const data: AddToCartData = {
         currency: 'USD',
         event: 'addToCart',
         eventName: 'vtex:addToCart',
-        items: [cartItem as CartItem],
+        items: [cartItem1 as CartItem, cartItem2 as CartItem],
       }
 
       const message = new MessageEvent('message', { data })
@@ -198,7 +209,7 @@ describe('GA4 events', () => {
 
       expect(mockedUpdate).toHaveBeenCalledWith('add_to_cart', {
         currency: 'USD',
-        value: 197.99,
+        value: 348.89,
         items: [
           {
             item_id: '200000202',
@@ -208,6 +219,15 @@ describe('GA4 events', () => {
             item_category: 'Home & Decor',
             quantity: 1,
             price: 197.99,
+          },
+          {
+            item_id: '200000203',
+            item_brand: 'Sony',
+            item_name: 'Top Wood 2',
+            item_variant: '2000305',
+            item_category: 'Home & Decor',
+            quantity: 1,
+            price: 150.9,
           },
         ],
       })

--- a/react/modules/enhancedEcommerceEvents.ts
+++ b/react/modules/enhancedEcommerceEvents.ts
@@ -12,8 +12,14 @@ import {
   ProductViewReferenceId,
 } from '../typings/events'
 import { AnalyticsEcommerceProduct } from '../typings/gtm'
-import { selectItem, selectPromotion, viewItem, viewItemList } from './gaEvents'
-import { getCategory, getSeller } from './utils'
+import {
+  addToCart,
+  selectItem,
+  selectPromotion,
+  viewItem,
+  viewItemList,
+} from './gaEvents'
+import { getCategory, getSeller, getProductNameWithoutVariant } from './utils'
 
 const defaultReference = { Value: '' }
 
@@ -161,6 +167,7 @@ export async function sendEnhancedEcommerceEvents(e: PixelMessage) {
         event: 'addToCart',
       }
 
+      addToCart(e.data)
       updateEcommerce('addToCart', data)
 
       return
@@ -380,17 +387,4 @@ function getCheckoutProductObjectData(
     dimension2: item.referenceId ?? '', // SKU reference id
     dimension3: item.skuName,
   }
-}
-
-function getProductNameWithoutVariant(
-  productNameWithVariant: string,
-  variant: string
-) {
-  const indexOfVariant = productNameWithVariant.lastIndexOf(variant)
-
-  if (indexOfVariant === -1 || indexOfVariant === 0) {
-    return productNameWithVariant
-  }
-
-  return productNameWithVariant.substring(0, indexOfVariant - 1) // Removes the variant and the whitespace
 }

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -1,4 +1,4 @@
-import { PixelMessage, CartItem } from '../typings/events'
+import { PixelMessage, AddToCartData, CartItem } from '../typings/events'
 import updateEcommerce from './updateEcommerce'
 import {
   getPrice,
@@ -120,7 +120,7 @@ export function selectPromotion(eventData: PixelMessage['data']) {
   updateEcommerce(eventName, { ecommerce: data })
 }
 
-export function addToCart(eventData: PixelMessage['data']) {
+export function addToCart(eventData: AddToCartData) {
   if (!shouldMergeUAEvents()) return
 
   const eventName = 'add_to_cart'
@@ -140,9 +140,9 @@ export function addToCart(eventData: PixelMessage['data']) {
       item_brand: item.brand,
       item_name: productName,
       item_variant: item.skuId,
-      item_category: item.category,
       quantity: item.quantity,
       price: formattedPrice,
+      ...getCategoriesWithHierarchy([item.category]),
     }
   })
 

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -152,5 +152,5 @@ export function addToCart(eventData: AddToCartData) {
     value: totalValue,
   }
 
-  updateEcommerce(eventName, data)
+  updateEcommerce(eventName, { ecommerce: data })
 }

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -1,4 +1,4 @@
-import { PixelMessage, CartItem } from '../typings/events'
+import { PixelMessage } from '../typings/events'
 import updateEcommerce from './updateEcommerce'
 import {
   getPrice,
@@ -124,33 +124,28 @@ export function addToCart(eventData: PixelMessage['data']) {
   if (!shouldMergeUAEvents()) return
 
   const eventName = 'add_to_cart'
-  const { currency, items } = eventData
 
-  const formattedPrices = items.map((item: CartItem) =>
+  const {
+    currency,
+    items: [item],
+  } = eventData
+
+  const productName = getProductNameWithoutVariant(item.name, item.skuName)
+  const formattedPrice =
     item.priceIsInt === true ? item.price / 100 : item.price
-  )
-
-  const totalValue = formattedPrices.reduce(
-    (accumulator: number, currentValue: number) => accumulator + currentValue,
-    0
-  )
 
   const data = {
     currency,
-    value: totalValue,
-    items: items.map((item: CartItem) => {
-      const productName = getProductNameWithoutVariant(item.name, item.skuName)
-
-      return {
-        item_id: item.productId,
-        item_brand: item.brand,
-        item_name: productName,
-        item_variant: item.skuId,
-        item_category: item.category,
-        quantity: item.quantity,
-        price: item.priceIsInt === true ? item.price / 100 : item.price,
-      }
-    }),
+    value: formattedPrice,
+    items: {
+      item_id: item.productId,
+      item_brand: item.brand,
+      item_name: productName,
+      item_variant: item.skuId,
+      item_category: item.category,
+      quantity: item.quantity,
+      price: formattedPrice,
+    },
   }
 
   updateEcommerce(eventName, data)

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -137,15 +137,17 @@ export function addToCart(eventData: PixelMessage['data']) {
   const data = {
     currency,
     value: formattedPrice,
-    items: {
-      item_id: item.productId,
-      item_brand: item.brand,
-      item_name: productName,
-      item_variant: item.skuId,
-      item_category: item.category,
-      quantity: item.quantity,
-      price: formattedPrice,
-    },
+    items: [
+      {
+        item_id: item.productId,
+        item_brand: item.brand,
+        item_name: productName,
+        item_variant: item.skuId,
+        item_category: item.category,
+        quantity: item.quantity,
+        price: formattedPrice,
+      },
+    ],
   }
 
   updateEcommerce(eventName, data)

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -1,4 +1,4 @@
-import { PixelMessage } from '../typings/events'
+import { PixelMessage, CartItem } from '../typings/events'
 import updateEcommerce from './updateEcommerce'
 import {
   getPrice,
@@ -125,29 +125,31 @@ export function addToCart(eventData: PixelMessage['data']) {
 
   const eventName = 'add_to_cart'
 
-  const {
-    currency,
-    items: [item],
-  } = eventData
+  const { items: eventDataItems, currency } = eventData
 
-  const productName = getProductNameWithoutVariant(item.name, item.skuName)
-  const formattedPrice =
-    item.priceIsInt === true ? item.price / 100 : item.price
+  let totalValue = 0.0
+  const items = eventDataItems.map((item: CartItem) => {
+    const productName = getProductNameWithoutVariant(item.name, item.skuName)
+    const formattedPrice =
+      item.priceIsInt === true ? item.price / 100 : item.price
+
+    totalValue += formattedPrice
+
+    return {
+      item_id: item.productId,
+      item_brand: item.brand,
+      item_name: productName,
+      item_variant: item.skuId,
+      item_category: item.category,
+      quantity: item.quantity,
+      price: formattedPrice,
+    }
+  })
 
   const data = {
+    items,
     currency,
-    value: formattedPrice,
-    items: [
-      {
-        item_id: item.productId,
-        item_brand: item.brand,
-        item_name: productName,
-        item_variant: item.skuId,
-        item_category: item.category,
-        quantity: item.quantity,
-        price: formattedPrice,
-      },
-    ],
+    value: totalValue,
   }
 
   updateEcommerce(eventName, data)

--- a/react/modules/utils.ts
+++ b/react/modules/utils.ts
@@ -131,3 +131,16 @@ function splitIntoCategories(category?: string) {
 
   return splitted
 }
+
+export function getProductNameWithoutVariant(
+  productNameWithVariant: string,
+  variant: string
+) {
+  const indexOfVariant = productNameWithVariant.lastIndexOf(variant)
+
+  if (indexOfVariant === -1 || indexOfVariant === 0) {
+    return productNameWithVariant
+  }
+
+  return productNameWithVariant.substring(0, indexOfVariant - 1) // Removes the variant and the whitespace
+}

--- a/react/modules/utils.ts
+++ b/react/modules/utils.ts
@@ -125,7 +125,7 @@ export function removeStartAndEndSlash(category?: string) {
 }
 
 function splitIntoCategories(category?: string) {
-  if (!category || !category.includes('/')) return
+  if (!category) return
 
   const splitted = category.split('/')
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR intends to add the `add_to_cart` GA4 event to be sent when `vtex:addToCart` is received.

[`add_to_cart` event](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?hl=en&client_type=gtag#add_to_cart)|
-|
![Screen Shot 2023-02-08 at 16 09 23](https://user-images.githubusercontent.com/15722605/217628290-5a2275a3-eb0f-4e8b-9982-2475f916d1b1.png)|

#### How should this be manually tested?

- In your local environment, inside the `google-tag-manager` app repository, go to the branch `feat/ga4-add-to-cart-event`;
- Login in your preferred account and workspace;
- Link the app;
- Go to the Admin and access the App Store. Look for the Google Tag Manager app and access the `Settings`;
- Check the `Merge Universal Analytics and Google Analytics 4 Events` option;
- Access the store and perform add an item to the cart;
- Check the `dataLayer` object (just type `dataLayer` in the console and press enter). The event data should be in the list.

![Screen Shot 2023-02-08 at 17 48 57](https://user-images.githubusercontent.com/15722605/217649666-f0198fe8-7d97-463c-af8b-510d8f7249a7.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
