### PR TITLE
feat: Adds `remove_from_cart` GA4 event

### DIFF
--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -7,6 +7,7 @@ import {
   Promotion,
   PromotionClickData,
   AddToCartData,
+  RemoveFromCartData,
   CartItem,
 } from '../typings/events'
 import shouldMergeUAEvents from '../modules/utils/shouldMergeUAEvents'
@@ -158,6 +159,58 @@ describe('GA4 events', () => {
         creative_slot: 'featured_app_1',
         promotion_id: 'P_12345',
         promotion_name: 'Summer Sale',
+      })
+    })
+
+    it('sends an event that signifies an item being removed from cart', () => {
+      type CartItemMockType = Pick<
+        CartItem,
+        | 'name'
+        | 'brand'
+        | 'price'
+        | 'skuId'
+        | 'skuName'
+        | 'quantity'
+        | 'category'
+        | 'productId'
+      >
+
+      const cartItem: CartItemMockType = {
+        productId: '200000202',
+        skuId: '2000304',
+        brand: 'Sony',
+        name: 'Top Wood',
+        skuName: 'top_wood_200',
+        price: 197.99,
+        category: 'Home & Decor',
+        quantity: 1,
+      }
+
+      const data: RemoveFromCartData = {
+        currency: 'USD',
+        event: 'removeFromCart',
+        eventName: 'vtex:removeFromCart',
+        items: [cartItem as CartItem],
+      }
+
+      const message = new MessageEvent('message', { data })
+
+      handleEvents(message)
+
+      expect(mockedUpdate).toHaveBeenCalledWith('remove_from_cart', {
+        currency: 'USD',
+        value: 197.99,
+        items: [
+          {
+            item_id: '200000202',
+            item_brand: 'Sony',
+            item_name: 'Top Wood',
+            item_variant: '2000304',
+            item_category: 'Home & Decor',
+            quantity: 1,
+            price: 197.99,
+          },
+        ],
       })
     })
   })

--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -161,7 +161,9 @@ describe('GA4 events', () => {
         promotion_name: 'Summer Sale',
       })
     })
+  })
 
+  describe('remove_from_cart', () => {
     it('sends an event that signifies an item being removed from cart', () => {
       type CartItemMockType = Pick<
         CartItem,

--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -155,64 +155,12 @@ describe('GA4 events', () => {
       handleEvents(message)
 
       expect(mockedUpdate).toHaveBeenCalledWith('select_promotion', {
-        creative_name: 'Summer Banner',
-        creative_slot: 'featured_app_1',
-        promotion_id: 'P_12345',
-        promotion_name: 'Summer Sale',
-      })
-    })
-  })
-
-  describe('remove_from_cart', () => {
-    it('sends an event that signifies an item being removed from cart', () => {
-      type CartItemMockType = Pick<
-        CartItem,
-        | 'name'
-        | 'brand'
-        | 'price'
-        | 'skuId'
-        | 'skuName'
-        | 'quantity'
-        | 'category'
-        | 'productId'
-      >
-
-      const cartItem: CartItemMockType = {
-        productId: '200000202',
-        skuId: '2000304',
-        brand: 'Sony',
-        name: 'Top Wood',
-        skuName: 'top_wood_200',
-        price: 197.99,
-        category: 'Home & Decor',
-        quantity: 1,
-      }
-
-      const data: RemoveFromCartData = {
-        currency: 'USD',
-        event: 'removeFromCart',
-        eventName: 'vtex:removeFromCart',
-        items: [cartItem as CartItem],
-      }
-
-      const message = new MessageEvent('message', { data })
-
-      handleEvents(message)
-
-      expect(mockedUpdate).toHaveBeenCalledWith('remove_from_cart', {
-        currency: 'USD',
-        value: 197.99,
-        items: [
-          {
-            item_id: '200000202',
-            item_brand: 'Sony',
-            item_name: 'Top Wood',
-            item_variant: '2000304',
-            item_category: 'Home & Decor',
-            quantity: 1,
-            price: 197.99,
-          },
-        ],
+        ecommerce: {
+          creative_name: 'Summer Banner',
+          creative_slot: 'featured_app_1',
+          promotion_id: 'P_12345',
+          promotion_name: 'Summer Sale',
+        },
       })
     })
   })
@@ -265,29 +213,87 @@ describe('GA4 events', () => {
       handleEvents(message)
 
       expect(mockedUpdate).toHaveBeenCalledWith('add_to_cart', {
+        ecommerce: {
+          currency: 'USD',
+          value: 348.89,
+          items: [
+            {
+              item_id: '200000202',
+              item_brand: 'Sony',
+              item_name: 'Top Wood',
+              item_variant: '2000304',
+              item_category: 'Home & Decor',
+              quantity: 1,
+              price: 197.99,
+            },
+            {
+              item_id: '200000203',
+              item_brand: 'Sony',
+              item_name: 'Top Wood 2',
+              item_variant: '2000305',
+              item_category: 'Home & Decor',
+              item_category2: 'Tables',
+              quantity: 1,
+              price: 150.9,
+            },
+          ],
+        },
+      })
+    })
+  })
+
+  describe('remove_from_cart', () => {
+    it('sends an event that signifies an item being removed from cart', () => {
+      type CartItemMockType = Pick<
+        CartItem,
+        | 'name'
+        | 'brand'
+        | 'price'
+        | 'skuId'
+        | 'skuName'
+        | 'quantity'
+        | 'category'
+        | 'productId'
+      >
+
+      const cartItem: CartItemMockType = {
+        productId: '200000202',
+        skuId: '2000304',
+        brand: 'Sony',
+        name: 'Top Wood',
+        skuName: 'top_wood_200',
+        price: 197.99,
+        category: 'Home & Decor',
+        quantity: 1,
+      }
+
+      const data: RemoveFromCartData = {
         currency: 'USD',
-        value: 348.89,
-        items: [
-          {
-            item_id: '200000202',
-            item_brand: 'Sony',
-            item_name: 'Top Wood',
-            item_variant: '2000304',
-            item_category: 'Home & Decor',
-            quantity: 1,
-            price: 197.99,
-          },
-          {
-            item_id: '200000203',
-            item_brand: 'Sony',
-            item_name: 'Top Wood 2',
-            item_variant: '2000305',
-            item_category: 'Home & Decor',
-            item_category2: 'Tables',
-            quantity: 1,
-            price: 150.9,
-          },
-        ],
+        event: 'removeFromCart',
+        eventName: 'vtex:removeFromCart',
+        items: [cartItem as CartItem],
+      }
+
+      const message = new MessageEvent('message', { data })
+
+      handleEvents(message)
+
+      expect(mockedUpdate).toHaveBeenCalledWith('remove_from_cart', {
+        ecommerce: {
+          currency: 'USD',
+          value: 197.99,
+          items: [
+            {
+              item_id: '200000202',
+              item_brand: 'Sony',
+              item_name: 'Top Wood',
+              item_variant: '2000304',
+              item_category: 'Home & Decor',
+              quantity: 1,
+              price: 197.99,
+            },
+          ],
+        },
       })
     })
   })

--- a/react/modules/enhancedEcommerceEvents.ts
+++ b/react/modules/enhancedEcommerceEvents.ts
@@ -6,18 +6,19 @@ import {
   Impression,
   CartItem,
   AddToCartData,
-  RemoveToCartData,
+  RemoveFromCartData,
   ProductViewData,
   ProductClickData,
   ProductViewReferenceId,
 } from '../typings/events'
 import { AnalyticsEcommerceProduct } from '../typings/gtm'
 import {
-  addToCart,
   selectItem,
   selectPromotion,
   viewItem,
   viewItemList,
+  addToCart,
+  removeFromCart,
 } from './gaEvents'
 import { getCategory, getSeller, getProductNameWithoutVariant } from './utils'
 
@@ -174,7 +175,7 @@ export async function sendEnhancedEcommerceEvents(e: PixelMessage) {
     }
 
     case 'vtex:removeFromCart': {
-      const { items } = e.data as RemoveToCartData
+      const { items } = e.data as RemoveFromCartData
 
       const data = {
         ecommerce: {
@@ -200,6 +201,7 @@ export async function sendEnhancedEcommerceEvents(e: PixelMessage) {
         event: 'removeFromCart',
       }
 
+      removeFromCart(e.data)
       updateEcommerce('removeFromCart', data)
 
       return

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -1,4 +1,9 @@
-import { PixelMessage, AddToCartData, CartItem } from '../typings/events'
+import {
+  CartItem,
+  PixelMessage,
+  AddToCartData,
+  RemoveFromCartData,
+} from '../typings/events'
 import updateEcommerce from './updateEcommerce'
 import {
   getPrice,
@@ -155,7 +160,7 @@ export function addToCart(eventData: AddToCartData) {
   updateEcommerce(eventName, { ecommerce: data })
 }
 
-export function removeFromCart(eventData: PixelMessage['data']) {
+export function removeFromCart(eventData: RemoveFromCartData) {
   if (!shouldMergeUAEvents()) return
 
   const eventName = 'remove_from_cart'
@@ -175,9 +180,9 @@ export function removeFromCart(eventData: PixelMessage['data']) {
       item_brand: item.brand,
       item_name: productName,
       item_variant: item.skuId,
-      item_category: item.category,
       quantity: item.quantity,
       price: formattedPrice,
+      ...getCategoriesWithHierarchy([item.category]),
     }
   })
 

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -192,5 +192,5 @@ export function removeFromCart(eventData: RemoveFromCartData) {
     value: totalValue,
   }
 
-  updateEcommerce(eventName, data)
+  updateEcommerce(eventName, { ecommerce: data })
 }

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -160,29 +160,31 @@ export function removeFromCart(eventData: PixelMessage['data']) {
 
   const eventName = 'remove_from_cart'
 
-  const {
-    currency,
-    items: [item],
-  } = eventData
+  const { items: eventDataItems, currency } = eventData
 
-  const productName = getProductNameWithoutVariant(item.name, item.skuName)
-  const formattedPrice =
-    item.priceIsInt === true ? item.price / 100 : item.price
+  let totalValue = 0.0
+  const items = eventDataItems.map((item: CartItem) => {
+    const productName = getProductNameWithoutVariant(item.name, item.skuName)
+    const formattedPrice =
+      item.priceIsInt === true ? item.price / 100 : item.price
+
+    totalValue += formattedPrice
+
+    return {
+      item_id: item.productId,
+      item_brand: item.brand,
+      item_name: productName,
+      item_variant: item.skuId,
+      item_category: item.category,
+      quantity: item.quantity,
+      price: formattedPrice,
+    }
+  })
 
   const data = {
+    items,
     currency,
-    value: formattedPrice,
-    items: [
-      {
-        item_id: item.productId,
-        item_brand: item.brand,
-        item_name: productName,
-        item_variant: item.skuId,
-        item_category: item.category,
-        quantity: item.quantity,
-        price: formattedPrice,
-      },
-    ],
+    value: totalValue,
   }
 
   updateEcommerce(eventName, data)

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -154,3 +154,36 @@ export function addToCart(eventData: AddToCartData) {
 
   updateEcommerce(eventName, { ecommerce: data })
 }
+
+export function removeFromCart(eventData: PixelMessage['data']) {
+  if (!shouldMergeUAEvents()) return
+
+  const eventName = 'remove_from_cart'
+
+  const {
+    currency,
+    items: [item],
+  } = eventData
+
+  const productName = getProductNameWithoutVariant(item.name, item.skuName)
+  const formattedPrice =
+    item.priceIsInt === true ? item.price / 100 : item.price
+
+  const data = {
+    currency,
+    value: formattedPrice,
+    items: [
+      {
+        item_id: item.productId,
+        item_brand: item.brand,
+        item_name: productName,
+        item_variant: item.skuId,
+        item_category: item.category,
+        quantity: item.quantity,
+        price: formattedPrice,
+      },
+    ],
+  }
+
+  updateEcommerce(eventName, data)
+}

--- a/react/typings/events.d.ts
+++ b/react/typings/events.d.ts
@@ -7,7 +7,7 @@ export interface PixelMessage extends MessageEvent {
     | PageViewData
     | ProductImpressionData
     | AddToCartData
-    | RemoveToCartData
+    | RemoveFromCartData
     | CartChangedData
     | HomePageInfo
     | ProductPageInfoData
@@ -100,7 +100,7 @@ export interface AddToCartData extends EventData {
   items: CartItem[]
 }
 
-export interface RemoveToCartData extends EventData {
+export interface RemoveFromCartData extends EventData {
   event: 'removeFromCart'
   eventName: 'vtex:removeFromCart'
   items: CartItem[]


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR intends to add the `remove_from_cart` GA4 event to be sent when `vtex:removeFromCart` is received.

[`remove_from_cart` event](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?hl=en&client_type=gtag#remove_from_cart)|
-|
![Screen Shot 2023-02-10 at 16 58 20](https://user-images.githubusercontent.com/15722605/218186124-d9e080c6-6595-4ea7-b0c0-44661090f44a.png)|

#### How should this be manually tested?

- In your local environment, inside the `google-tag-manager` app repository, go to the branch `feat/ga4-remove-from-cart-event`;
- Login in your preferred account and workspace;
- Link the app;
- Go to the Admin and access the App Store. Look for the Google Tag Manager app and access the `Settings`;
- Check the `Merge Universal Analytics and Google Analytics 4 Events` option;
- Access the store and perform add an item to the cart;
- Check the `dataLayer` object (just type `dataLayer` in the console and press enter). The event data should be in the list.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
