### PR TITLE
Feat/ga4 purchase event

### DIFF
--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -361,23 +361,25 @@ describe('GA4 events', () => {
       handleEvents(message)
 
       expect(mockedUpdate).toHaveBeenCalledWith('purchase', {
-        coupon: null,
-        currency: 'USD',
-        items: [
-          {
-            item_brand: 'New Offers!!',
-            item_category: 'Apparel & Accessories',
-            item_id: '9',
-            item_name: 'Top Everyday Necessaire',
-            item_variant: '20',
-            price: 1600.99,
-            quantity: 1,
-          },
-        ],
-        shipping: 1942.61,
-        tax: 0,
-        transaction_id: '1310750551387',
-        value: 3543.6,
+        ecommerce: {
+          coupon: null,
+          currency: 'USD',
+          items: [
+            {
+              item_brand: 'New Offers!!',
+              item_category: 'Apparel & Accessories',
+              item_id: '9',
+              item_name: 'Top Everyday Necessaire',
+              item_variant: '20',
+              price: 1600.99,
+              quantity: 1,
+            },
+          ],
+          shipping: 1942.61,
+          tax: 0,
+          transaction_id: '1310750551387',
+          value: 3543.6,
+        },
       })
     })
   })

--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -156,4 +156,88 @@ describe('GA4 events', () => {
       })
     })
   })
+
+  describe('purchase', () => {
+    it('sends an event that signifies a successful checkout on orderPlaced page', () => {
+      const transactionProducts = [
+        {
+          attachments: [],
+          brand: 'New Offers!!',
+          brandId: '2000045',
+          category: 'Apparel & Accessories',
+          categoryId: '25',
+          categoryIdTree: ['25'],
+          categoryTree: ['Apparel & Accessories'],
+          components: [],
+          ean: '9812983',
+          id: '9',
+          measurementUnit: 'un',
+          name: 'Top Everyday Necessaire 100 RMS',
+          originalPrice: 1600.99,
+          price: 1600.99,
+          priceTags: [],
+          productRefId: '',
+          quantity: 1,
+          seller: 'VTEX',
+          sellerId: '1',
+          sellingPrice: 1600.99,
+          sku: '20',
+          skuName: '100 RMS',
+          skuRefId: '9812983',
+          slug: 'everyday-necessaire',
+          tax: 0,
+          unitMultiplier: 1,
+        },
+      ]
+
+      const data = {
+        accountName: 'storecomponents',
+        corporateName: null,
+        currency: 'USD',
+        event: 'orderPlaced',
+        eventName: 'vtex:orderPlaced',
+        openTextField: null,
+        orderGroup: '1310750551387',
+        ordersInOrderGroup: ['1310750551387-01'],
+        salesChannel: '1',
+        transactionAffiliation: 'VTEX',
+        transactionCurrency: 'USD',
+        transactionCustomTaxes: {},
+        transactionDate: '2023-02-14T18:56:47.0019167Z',
+        transactionDiscounts: 0,
+        transactionId: '1310750551387',
+        transactionLatestShippingEstimate: '2023-02-15T18:56:52.1493235Z',
+        transactionPayment: { id: 'FCE420A6B22C45D3BD60FD5DB55D34D1' },
+        transactionShipping: 1942.61,
+        transactionProducts,
+        transactionSubtotal: 1600.99,
+        transactionTax: 0,
+        transactionTotal: 3543.6,
+      }
+
+      const message = new MessageEvent('message', { data })
+
+      handleEvents(message)
+
+      expect(mockedUpdate).toHaveBeenCalledWith('purchase', {
+        coupon: null,
+        currency: 'USD',
+        items: [
+          {
+            item_brand: 'New Offers!!',
+            item_category: 'Apparel & Accessories',
+            item_id: '9',
+            item_name: 'Top Everyday Necessaire',
+            item_variant: '20',
+            price: 1600.99,
+            quantity: 1,
+          },
+        ],
+        shipping: 1942.61,
+        tax: 0,
+        transaction_id: '1310750551387',
+        value: 3543.6,
+      })
+    })
+  })
 })

--- a/react/modules/enhancedEcommerceEvents.ts
+++ b/react/modules/enhancedEcommerceEvents.ts
@@ -9,6 +9,7 @@ import {
   ProductViewData,
   ProductClickData,
   ProductViewReferenceId,
+  OrderPlacedData,
 } from '../typings/events'
 import { AnalyticsEcommerceProduct } from '../typings/gtm'
 import {
@@ -213,7 +214,7 @@ export async function sendEnhancedEcommerceEvents(e: PixelMessage) {
     }
 
     case 'vtex:orderPlaced': {
-      const order = e.data
+      const order = e.data as OrderPlacedData
 
       const ecommerce = {
         purchase: {

--- a/react/modules/enhancedEcommerceEvents.ts
+++ b/react/modules/enhancedEcommerceEvents.ts
@@ -1,6 +1,5 @@
 import updateEcommerce from './updateEcommerce'
 import {
-  Order,
   PixelMessage,
   ProductOrder,
   Impression,
@@ -12,8 +11,19 @@ import {
   ProductViewReferenceId,
 } from '../typings/events'
 import { AnalyticsEcommerceProduct } from '../typings/gtm'
-import { selectItem, selectPromotion, viewItem, viewItemList } from './gaEvents'
-import { getCategory, getSeller } from './utils'
+import {
+  purchase,
+  selectItem,
+  selectPromotion,
+  viewItem,
+  viewItemList,
+} from './gaEvents'
+import {
+  getCategory,
+  getProductNameWithoutVariant,
+  getPurchaseObjectData,
+  getSeller,
+} from './utils'
 
 const defaultReference = { Value: '' }
 
@@ -225,6 +235,7 @@ export async function sendEnhancedEcommerceEvents(e: PixelMessage) {
         },
       }
 
+      purchase(order)
       updateEcommerce('orderPlaced', data)
 
       return
@@ -312,17 +323,6 @@ export async function sendEnhancedEcommerceEvents(e: PixelMessage) {
   }
 }
 
-function getPurchaseObjectData(order: Order) {
-  return {
-    affiliation: order.transactionAffiliation,
-    coupon: order.coupon ? order.coupon : null,
-    id: order.orderGroup,
-    revenue: order.transactionTotal,
-    shipping: order.transactionShipping,
-    tax: order.transactionTax,
-  }
-}
-
 function getProductObjectData(product: ProductOrder) {
   const productName = getProductNameWithoutVariant(
     product.name,
@@ -380,17 +380,4 @@ function getCheckoutProductObjectData(
     dimension2: item.referenceId ?? '', // SKU reference id
     dimension3: item.skuName,
   }
-}
-
-function getProductNameWithoutVariant(
-  productNameWithVariant: string,
-  variant: string
-) {
-  const indexOfVariant = productNameWithVariant.lastIndexOf(variant)
-
-  if (indexOfVariant === -1 || indexOfVariant === 0) {
-    return productNameWithVariant
-  }
-
-  return productNameWithVariant.substring(0, indexOfVariant - 1) // Removes the variant and the whitespace
 }

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -3,6 +3,7 @@ import {
   PixelMessage,
   AddToCartData,
   RemoveFromCartData,
+  OrderPlacedData,
 } from '../typings/events'
 import updateEcommerce from './updateEcommerce'
 import {
@@ -197,7 +198,7 @@ export function removeFromCart(eventData: RemoveFromCartData) {
   updateEcommerce(eventName, { ecommerce: data })
 }
 
-export function purchase(eventData: PixelMessage['data']) {
+export function purchase(eventData: OrderPlacedData) {
   if (!shouldMergeUAEvents()) return
 
   const eventName = 'purchase'
@@ -220,5 +221,5 @@ export function purchase(eventData: PixelMessage['data']) {
     currency,
   }
 
-  updateEcommerce(eventName, data)
+  updateEcommerce(eventName, { ecommerce: data })
 }

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -7,6 +7,8 @@ import {
   getQuantity,
   getImpressions,
   getDiscount,
+  getPurchaseObjectData,
+  getPurchaseItems,
 } from './utils'
 import shouldMergeUAEvents from './utils/shouldMergeUAEvents'
 
@@ -114,6 +116,31 @@ export function selectPromotion(eventData: PixelMessage['data']) {
     creative_slot: promotion.position,
     promotion_id: promotion.id,
     promotion_name: promotion.name,
+  }
+
+  updateEcommerce(eventName, data)
+}
+
+export function purchase(eventData: PixelMessage['data']) {
+  if (!shouldMergeUAEvents()) return
+
+  const eventName = 'purchase'
+
+  const { id, revenue, tax, shipping, coupon } = getPurchaseObjectData(
+    eventData
+  )
+
+  const { transactionProducts } = eventData
+
+  const items = getPurchaseItems(transactionProducts)
+
+  const data = {
+    transaction_id: id,
+    value: revenue,
+    tax,
+    shipping,
+    coupon,
+    items,
   }
 
   updateEcommerce(eventName, data)

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -130,7 +130,7 @@ export function purchase(eventData: PixelMessage['data']) {
     eventData
   )
 
-  const { transactionProducts } = eventData
+  const { transactionProducts, currency } = eventData
 
   const items = getPurchaseItems(transactionProducts)
 
@@ -141,6 +141,7 @@ export function purchase(eventData: PixelMessage['data']) {
     shipping,
     coupon,
     items,
+    currency,
   }
 
   updateEcommerce(eventName, data)

--- a/react/modules/utils.ts
+++ b/react/modules/utils.ts
@@ -168,14 +168,12 @@ function formatPurchaseProduct(product: ProductOrder) {
     item_variant: sku,
     price,
     quantity,
-    item_category: category,
+    ...getCategoriesWithHierarchy([category]),
   }
 
   return item
 }
 
 export function getPurchaseItems(orderProducts: ProductOrder[]) {
-  return orderProducts.map((product: ProductOrder) =>
-    formatPurchaseProduct(product)
-  )
+  return orderProducts.map(formatPurchaseProduct)
 }

--- a/react/modules/utils.ts
+++ b/react/modules/utils.ts
@@ -1,4 +1,4 @@
-import { Impression, Seller } from '../typings/events'
+import { Impression, Order, ProductOrder, Seller } from '../typings/events'
 
 export function getSeller(sellers: Seller[]) {
   const defaultSeller = sellers.find(seller => seller.sellerDefault)
@@ -130,4 +130,52 @@ function splitIntoCategories(category?: string) {
   const splitted = category.split('/')
 
   return splitted
+}
+
+export function getPurchaseObjectData(order: Order) {
+  return {
+    affiliation: order.transactionAffiliation,
+    coupon: order.coupon ? order.coupon : null,
+    id: order.orderGroup,
+    revenue: order.transactionTotal,
+    shipping: order.transactionShipping,
+    tax: order.transactionTax,
+  }
+}
+
+export function getProductNameWithoutVariant(
+  productNameWithVariant: string,
+  variant: string
+) {
+  const indexOfVariant = productNameWithVariant.lastIndexOf(variant)
+
+  if (indexOfVariant === -1 || indexOfVariant === 0) {
+    return productNameWithVariant
+  }
+
+  return productNameWithVariant.substring(0, indexOfVariant - 1) // Removes the variant and the whitespace
+}
+
+function formatPurchaseProduct(product: ProductOrder) {
+  const { name, skuName, id, brand, sku, price, quantity, category } = product
+
+  const productName = getProductNameWithoutVariant(name, skuName)
+
+  const item = {
+    item_id: id,
+    item_name: productName,
+    item_brand: brand,
+    item_variant: sku,
+    price,
+    quantity,
+    item_category: category,
+  }
+
+  return item
+}
+
+export function getPurchaseItems(orderProducts: ProductOrder[]) {
+  return orderProducts.map((product: ProductOrder) =>
+    formatPurchaseProduct(product)
+  )
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR intends to add the `purchase` GA4 event to be sent when `vtex:orderPlaced` is received.

[`purchase` event](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?hl=pt-br&client_type=gtag#purchase)|
-|
![Captura de Tela 2023-02-14 às 12 31 46](https://user-images.githubusercontent.com/36740164/218783507-d6c8bc46-6afa-4487-9132-bcf519a61eec.png)


#### How should this be manually tested?

- In your local environment, inside the `google-tag-manager` app repository, go to the branch `feat/ga4-remove-from-cart-event`;
- Login in your preferred account and workspace;
- Link the app;
- Go to the Admin and access the App Store. Look for the Google Tag Manager app and access the `Settings`;
- Check the `Merge Universal Analytics and Google Analytics 4 Events` option;
- Access the store and perform add an item to the cart and complete a checkout;
- Check the `dataLayer` object (just type `dataLayer` in the console and press enter). The event data should be in the list.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
