### PR TITLE
Add tests to GA4 `select_item`, `view_item` & `view_item_list`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,16 @@
 name: CI
 
-on: push
+on:
+  pull_request:
+    branches:
+    - master
+    - feat/settings-merge-ua-events # TODO: Remove once we're done.
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    
     steps:
     - uses: actions/checkout@v1
     - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,16 +1,12 @@
 name: CI
 
-on:
-  pull_request:
-    branches:
-    - master
-    - feat/settings-merge-ua-events # TODO: Remove once we're done.
+on: push
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: actions/checkout@v1
     - name: Run tests

--- a/react/__mocks__/productClick.ts
+++ b/react/__mocks__/productClick.ts
@@ -257,6 +257,8 @@ const productClick = {
       },
     },
   },
+  list: 'List of products',
+  position: 3,
 }
 
 export default productClick

--- a/react/__mocks__/productDetail.ts
+++ b/react/__mocks__/productDetail.ts
@@ -654,9 +654,9 @@ const productDetail = {
           commertialOffer: {
             discountHighlights: [],
             teasers: [],
-            Price: 38.9,
-            ListPrice: 38.9,
-            PriceWithoutDiscount: 38.9,
+            Price: 1540.99,
+            ListPrice: 1900.99,
+            // PriceWithoutDiscount: 38.9, the current event does not send this.
             RewardValue: 0,
             PriceValidUntil: '2020-09-05T22:07:59.9154441Z',
             AvailableQuantity: 2000000,

--- a/react/__mocks__/productDetail.ts
+++ b/react/__mocks__/productDetail.ts
@@ -791,6 +791,7 @@ const productDetail = {
       __typename: 'SKU',
     },
   },
+  list: 'List of products',
 }
 
 export default productDetail

--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -107,6 +107,9 @@ test('productClick', () => {
     event: 'productClick',
     ecommerce: {
       click: {
+        actionField: {
+          list: 'List of products',
+        },
         products: [
           {
             brand: 'Mizuno',
@@ -114,6 +117,7 @@ test('productClick', () => {
             id: '16',
             variant: '35',
             name: 'Classic Shoes Top',
+            position: 3,
             price: 38.9,
             dimension1: '12531',
             dimension2: '',

--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -141,6 +141,48 @@ describe('GA4 events', () => {
     mockedShouldMergeUAEvents.mockReturnValue(mergeUAEvents)
   })
 
+  describe('view_item_list', () => {
+    it('sends an event that signifies that some content was shown to the user', () => {
+      const message = new MessageEvent('message', {
+        data: productImpressionData,
+      })
+
+      handleEvents(message)
+
+      expect(mockedUpdate).toHaveBeenCalledWith('view_item_list', {
+        ecommerce: {
+          item_list_name: 'Shelf',
+          items: [
+            {
+              discount: 0,
+              index: 1,
+              item_brand: 'Mizuno',
+              item_category: 'Apparel & Accessories',
+              item_category2: 'Shoes',
+              item_id: '16',
+              item_name: 'Classic Shoes Top',
+              item_variant: '35',
+              price: 38.9,
+              quantity: 2000000,
+            },
+            {
+              discount: 0,
+              index: 2,
+              item_brand: 'Nintendo',
+              item_category: 'Apparel & Accessories',
+              item_category2: 'Watches',
+              item_id: '15',
+              item_name: 'Gorgeous Top Watch',
+              item_variant: '32',
+              price: 2200,
+              quantity: 2000000,
+            },
+          ],
+        },
+      })
+    })
+  })
+
   describe('view_item', () => {
     it('sends an event that signifies that some content was shown to the user', () => {
       const message = new MessageEvent('message', { data: productDetails })

--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -156,6 +156,7 @@ describe('GA4 events', () => {
               item_brand: 'Mizuno',
               item_variant: 'Classic Pink',
               index: undefined,
+              price: 1540.99,
               quantity: 2000000,
               discount: 0,
               item_category: 'Apparel & Accessories',

--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -84,7 +84,7 @@ test('productDetail', () => {
             id: '16',
             variant: '35',
             name: 'Classic Shoes Top',
-            price: 38.9,
+            price: 1540.99,
             dimension1: '',
             dimension2: '12531',
             dimension3: 'Classic Pink',
@@ -147,7 +147,7 @@ describe('GA4 events', () => {
       expect(mockedUpdate).toHaveBeenCalledWith('view_item', {
         ecommerce: {
           currency: 'USD',
-          value: 38.9,
+          value: 1540.99,
           items: [
             {
               item_id: '16',

--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -77,6 +77,9 @@ test('productDetail', () => {
     event: 'productDetail',
     ecommerce: {
       detail: {
+        actionField: {
+          list: 'List of products',
+        },
         products: [
           {
             brand: 'Mizuno',
@@ -152,7 +155,7 @@ describe('GA4 events', () => {
             {
               item_id: '16',
               item_name: 'Classic Shoes Top',
-              item_list_name: undefined,
+              item_list_name: 'List of products',
               item_brand: 'Mizuno',
               item_variant: 'Classic Pink',
               price: 1540.99,

--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -157,7 +157,7 @@ describe('GA4 events', () => {
               item_name: 'Classic Shoes Top',
               item_list_name: 'List of products',
               item_brand: 'Mizuno',
-              item_variant: 'Classic Pink',
+              item_variant: '35',
               price: 1540.99,
               quantity: 2000000,
               discount: 0,

--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -153,7 +153,7 @@ describe('GA4 events', () => {
               item_name: 'Classic Shoes Top',
               item_list_name: 'List of products',
               item_brand: 'Mizuno',
-              item_variant: 'Classic Pink',
+              item_variant: '35',
               index: 3,
               price: 38.9,
               quantity: 2000000,

--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -138,6 +138,35 @@ describe('GA4 events', () => {
     mockedShouldMergeUAEvents.mockReturnValue(mergeUAEvents)
   })
 
+  describe('select_item', () => {
+    it('sends an event that signifies an item was selected from a list', () => {
+      const message = new MessageEvent('message', { data: productClick })
+
+      handleEvents(message)
+
+      expect(mockedUpdate).toHaveBeenCalledWith('select_item', {
+        ecommerce: {
+          item_list_name: 'List of products',
+          items: [
+            {
+              item_id: '16',
+              item_name: 'Classic Shoes Top',
+              item_list_name: 'List of products',
+              item_brand: 'Mizuno',
+              item_variant: 'Classic Pink',
+              index: 3,
+              price: 38.9,
+              quantity: 2000000,
+              discount: 0,
+              item_category: 'Apparel & Accessories',
+              item_category2: 'Shoes',
+            },
+          ],
+        },
+      })
+    })
+  })
+
   describe('select_promotion', () => {
     it('sends an event that signifies a promotion was selected from a list', () => {
       const promotion: Promotion = {

--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -155,7 +155,6 @@ describe('GA4 events', () => {
               item_list_name: undefined,
               item_brand: 'Mizuno',
               item_variant: 'Classic Pink',
-              index: undefined,
               price: 1540.99,
               quantity: 2000000,
               discount: 0,

--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -138,6 +138,35 @@ describe('GA4 events', () => {
     mockedShouldMergeUAEvents.mockReturnValue(mergeUAEvents)
   })
 
+  describe('view_item', () => {
+    it('sends an event that signifies that some content was shown to the user', () => {
+      const message = new MessageEvent('message', { data: productDetails })
+
+      handleEvents(message)
+
+      expect(mockedUpdate).toHaveBeenCalledWith('view_item', {
+        ecommerce: {
+          currency: 'USD',
+          value: 38.9,
+          items: [
+            {
+              item_id: '16',
+              item_name: 'Classic Shoes Top',
+              item_list_name: undefined,
+              item_brand: 'Mizuno',
+              item_variant: 'Classic Pink',
+              index: undefined,
+              quantity: 2000000,
+              discount: 0,
+              item_category: 'Apparel & Accessories',
+              item_category2: 'Shoes',
+            },
+          ],
+        },
+      })
+    })
+  })
+
   describe('select_item', () => {
     it('sends an event that signifies an item was selected from a list', () => {
       const message = new MessageEvent('message', { data: productClick })

--- a/react/modules/enhancedEcommerceEvents.ts
+++ b/react/modules/enhancedEcommerceEvents.ts
@@ -12,6 +12,7 @@ import {
   PromoViewData,
   OrderPlacedData,
   ProductImpressionData,
+  CartLoadedData,
 } from '../typings/events'
 import { AnalyticsEcommerceProduct } from '../typings/gtm'
 import {
@@ -271,7 +272,7 @@ export async function sendEnhancedEcommerceEvents(e: PixelMessage) {
     }
 
     case 'vtex:cartLoaded': {
-      const { orderForm } = e.data
+      const { orderForm } = e.data as CartLoadedData
 
       const data = {
         event: 'checkout',

--- a/react/modules/enhancedEcommerceEvents.ts
+++ b/react/modules/enhancedEcommerceEvents.ts
@@ -309,7 +309,7 @@ export async function sendEnhancedEcommerceEvents(e: PixelMessage) {
     }
 
     case 'vtex:promotionClick': {
-      const { promotions } = e.data
+      const { promotions } = e.data as PromoViewData
 
       const data = {
         event: 'promotionClick',

--- a/react/modules/enhancedEcommerceEvents.ts
+++ b/react/modules/enhancedEcommerceEvents.ts
@@ -11,6 +11,7 @@ import {
   ProductViewReferenceId,
   PromoViewData,
   OrderPlacedData,
+  ProductImpressionData,
 } from '../typings/events'
 import { AnalyticsEcommerceProduct } from '../typings/gtm'
 import {
@@ -249,7 +250,7 @@ export async function sendEnhancedEcommerceEvents(e: PixelMessage) {
     }
 
     case 'vtex:productImpression': {
-      const { currency, list, impressions } = e.data
+      const { currency, list, impressions } = e.data as ProductImpressionData
 
       const parsedImpressions = (impressions || []).map(
         getProductImpressionObjectData(list)

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -1,6 +1,5 @@
 import {
   CartItem,
-  PixelMessage,
   AddToCartData,
   RemoveFromCartData,
   PromoViewData,

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -116,7 +116,7 @@ export function selectItem(eventData: ProductClickData) {
   updateEcommerce(eventName, { ecommerce: data })
 }
 
-export function selectPromotion(eventData: PixelMessage['data']) {
+export function selectPromotion(eventData: PromoViewData) {
   if (!shouldMergeUAEvents()) return
 
   const eventName = 'select_promotion'

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -47,6 +47,7 @@ export function viewItem(eventData: PixelMessage['data']) {
     index: position,
     discount,
     quantity,
+    price: value,
     ...categoriesHierarchy,
   }
 

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -85,7 +85,7 @@ export function selectItem(eventData: ProductClickData) {
 
   const { sku, productName, productId, categories, brand } = product
 
-  const { name: variant } = sku
+  const { itemId: variant } = sku
 
   const seller = getSeller(sku.sellers)
   const price = getPrice(seller)

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -27,7 +27,7 @@ export function viewItem(eventData: ProductViewData) {
 
   const eventName = 'view_item'
 
-  const { currency, product, list, position } = eventData
+  const { currency, product, list } = eventData
 
   const { selectedSku, productName, productId, categories, brand } = product
 
@@ -45,7 +45,6 @@ export function viewItem(eventData: ProductViewData) {
     item_list_name: list,
     item_brand: brand,
     item_variant: variant,
-    index: position,
     discount,
     quantity,
     price: value,

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -5,6 +5,7 @@ import {
   RemoveFromCartData,
   PromoViewData,
   OrderPlacedData,
+  ProductClickData,
 } from '../typings/events'
 import updateEcommerce from './updateEcommerce'
 import {
@@ -75,7 +76,7 @@ export function viewItemList(eventData: PixelMessage['data']) {
   updateEcommerce(eventName, { ecommerce: data })
 }
 
-export function selectItem(eventData: PixelMessage['data']) {
+export function selectItem(eventData: ProductClickData) {
   if (!shouldMergeUAEvents()) return
 
   const eventName = 'select_item'

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -7,6 +7,7 @@ import {
   OrderPlacedData,
   ProductClickData,
   ProductViewData,
+  ProductImpressionData,
 } from '../typings/events'
 import updateEcommerce from './updateEcommerce'
 import {
@@ -60,7 +61,7 @@ export function viewItem(eventData: ProductViewData) {
   updateEcommerce(eventName, { ecommerce: data })
 }
 
-export function viewItemList(eventData: PixelMessage['data']) {
+export function viewItemList(eventData: ProductImpressionData) {
   if (!shouldMergeUAEvents()) return
 
   const eventName = 'view_item_list'

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -6,6 +6,7 @@ import {
   PromoViewData,
   OrderPlacedData,
   ProductClickData,
+  ProductViewData,
 } from '../typings/events'
 import updateEcommerce from './updateEcommerce'
 import {
@@ -21,7 +22,7 @@ import {
 } from './utils'
 import shouldMergeUAEvents from './utils/shouldMergeUAEvents'
 
-export function viewItem(eventData: PixelMessage['data']) {
+export function viewItem(eventData: ProductViewData) {
   if (!shouldMergeUAEvents()) return
 
   const eventName = 'view_item'

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -31,7 +31,7 @@ export function viewItem(eventData: ProductViewData) {
 
   const { selectedSku, productName, productId, categories, brand } = product
 
-  const { name: variant } = selectedSku
+  const { itemId: variant } = selectedSku
 
   const seller = getSeller(selectedSku.sellers)
   const value = getPrice(seller)

--- a/react/modules/utils.ts
+++ b/react/modules/utils.ts
@@ -120,7 +120,7 @@ export function getCategory(rawCategories: string[]) {
 
 // Transform this: "/Apparel & Accessories/Clothing/Tops/"
 // To this: "Apparel & Accessories/Clothing/Tops"
-export function removeStartAndEndSlash(category?: string) {
+function removeStartAndEndSlash(category?: string) {
   return category?.replace(/^\/|\/$/g, '')
 }
 

--- a/react/typings/events.d.ts
+++ b/react/typings/events.d.ts
@@ -15,6 +15,7 @@ export interface PixelMessage extends MessageEvent {
     | UserData
     | CartIdData
     | CartData
+    | CartLoadedData
     | PromoViewData
     | PromotionClickData
 }

--- a/react/typings/events.d.ts
+++ b/react/typings/events.d.ts
@@ -407,11 +407,4 @@ export interface CommertialOffer {
   AvailableQuantity: number
 }
 
-export interface CategoryTreeItem {
-  href: string
-  id: number
-  name: string
-}
-
-export type CategoryTree = CategoryTreeItem[]
 export type ProductViewReferenceId = Array<Item['referenceId']>


### PR DESCRIPTION
#### What problem is this solving?

- Add tests to GA4 `select_item`, `view_item`, and `view_item_list` events.
- Remove unused types `CategoryTreeItem` and `CategoryTree`.
- Stop exporting the util function `removeStartAndEndSlash` because it's only used internally.
- Type event payloads for better safety.

#### How should this be manually tested?

Run new and existing tests with `yarn test`.