### PR TITLE
Feat/ga4 new add_payment_info event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support for sending GA4 [`remove_from_cart`](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#remove_from_cart) when `vtex:removeFromCart` is received.
 - Support for sending GA4 [`view_promotion`](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#view_promotion) when `vtex:promoView` is received.
 - Support for sending GA4 [`select_promotion`](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#select_promotion) when `vtex:promotionClick` is received.
+- Support for sending GA4 [`add_payment_info`](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#add_payment_info) when `vtex:addPaymentInfo` is received.
 
 ## [3.4.0] - 2023-02-15
 

--- a/react/__mocks__/addPaymentInfo.ts
+++ b/react/__mocks__/addPaymentInfo.ts
@@ -1,0 +1,25 @@
+const creditCardPaymentType = {
+  group: 'creditCard',
+  installments: 1,
+  paymentSystemName: 'Mastercard',
+  value: 21119,
+}
+
+const cartItem = {
+  productId: '200000202',
+  skuId: '2000304',
+  brand: 'Sony',
+  name: 'Top Wood',
+  skuName: 'top_wood_200',
+  price: 197.99,
+  category: 'Home & Decor',
+  quantity: 1,
+}
+
+export const creditCardPaymentInfo = {
+  eventName: 'vtex:addPaymentInfo',
+  event: 'addPaymentInfo',
+  payment: creditCardPaymentType,
+  items: [cartItem],
+  currency: 'USD',
+}

--- a/react/__mocks__/addPaymentInfo.ts
+++ b/react/__mocks__/addPaymentInfo.ts
@@ -16,7 +16,7 @@ const cartItem = {
   quantity: 1,
 }
 
-export const creditCardPaymentInfo = {
+export const creditCardPaymentInfoMock = {
   eventName: 'vtex:addPaymentInfo',
   event: 'addPaymentInfo',
   payment: creditCardPaymentType,

--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -12,6 +12,7 @@ import {
   CartItem,
 } from '../typings/events'
 import shouldMergeUAEvents from '../modules/utils/shouldMergeUAEvents'
+import { creditCardPaymentInfo } from '../__mocks__/addPaymentInfo'
 
 jest.mock('../modules/utils/shouldMergeUAEvents')
 
@@ -422,6 +423,35 @@ describe('GA4 events', () => {
             {
               item_id: 'SKU_30',
               item_name: 'Coffee Beans',
+            },
+          ],
+        },
+      })
+    })
+  })
+
+  describe('add_payment_info', () => {
+    it('sends an event when a user add a payment information (credit card)', () => {
+      const data = creditCardPaymentInfo
+
+      const message = new MessageEvent('message', { data })
+
+      handleEvents(message)
+
+      expect(mockedUpdate).toHaveBeenCalledWith('add_payment_info', {
+        ecommerce: {
+          currency: 'USD',
+          value: 211.19,
+          payment_type: 'creditCard',
+          items: [
+            {
+              item_id: '200000202',
+              item_brand: 'Sony',
+              item_name: 'Top Wood',
+              item_variant: '2000304',
+              item_category: 'Home & Decor',
+              quantity: 1,
+              price: 197.99,
             },
           ],
         },

--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -11,7 +11,7 @@ import {
   RemoveFromCartData,
   CartItem,
 } from '../typings/events'
-import { creditCardPaymentInfo } from '../__mocks__/addPaymentInfo'
+import { creditCardPaymentInfoMock } from '../__mocks__/addPaymentInfo'
 import shouldSendGA4Events from '../modules/utils/shouldSendGA4Events'
 
 jest.mock('../modules/utils/shouldSendGA4Events')
@@ -539,7 +539,7 @@ describe('GA4 events', () => {
 
   describe('add_payment_info', () => {
     it('sends an event when a user add a payment information (credit card)', () => {
-      const data = creditCardPaymentInfo
+      const data = creditCardPaymentInfoMock
 
       const message = new MessageEvent('message', { data })
 

--- a/react/modules/enhancedEcommerceEvents.ts
+++ b/react/modules/enhancedEcommerceEvents.ts
@@ -22,6 +22,7 @@ import {
   viewPromotion,
   addToCart,
   removeFromCart,
+  addPaymentInfo,
 } from './gaEvents'
 import {
   getCategory,
@@ -321,6 +322,12 @@ export async function sendEnhancedEcommerceEvents(e: PixelMessage) {
 
       selectPromotion(e.data)
       updateEcommerce('promotionClick', data)
+
+      break
+    }
+
+    case 'vtex:addPaymentInfo': {
+      addPaymentInfo(e.data)
 
       break
     }

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -1,5 +1,4 @@
 import {
-  CartItem,
   PixelMessage,
   AddToCartData,
   RemoveFromCartData,
@@ -225,14 +224,16 @@ export function addPaymentInfo(eventData: AddPaymentInfoData) {
   const eventName = 'add_payment_info'
 
   const { currency, payment, items: eventDataItems } = eventData
-  const { value, paymentSystemName } = payment
+  const { value, group } = payment
 
   const { items } = formatCartItemsAndValue(eventDataItems)
 
+  const formattedValue = value / 100
+
   const data = {
     currency,
-    value,
-    payment_type: paymentSystemName,
+    value: formattedValue,
+    payment_type: group,
     items,
   }
 

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -17,7 +17,6 @@ import {
   getDiscount,
   getPurchaseObjectData,
   getPurchaseItems,
-  getProductNameWithoutVariant,
   formatCartItemsAndValue,
 } from './utils'
 import shouldMergeUAEvents from './utils/shouldMergeUAEvents'

--- a/react/modules/utils.ts
+++ b/react/modules/utils.ts
@@ -1,4 +1,10 @@
-import { Impression, Order, ProductOrder, Seller } from '../typings/events'
+import {
+  CartItem,
+  Impression,
+  Order,
+  ProductOrder,
+  Seller,
+} from '../typings/events'
 
 export function getSeller(sellers: Seller[]) {
   const defaultSeller = sellers.find(seller => seller.sellerDefault)
@@ -172,6 +178,29 @@ function formatPurchaseProduct(product: ProductOrder) {
   }
 
   return item
+}
+
+export function formatCartItemsAndValue(cartItems: CartItem[]) {
+  let totalValue = 0.0
+  const items = cartItems.map((item: CartItem) => {
+    const productName = getProductNameWithoutVariant(item.name, item.skuName)
+    const formattedPrice =
+      item.priceIsInt === true ? item.price / 100 : item.price
+
+    totalValue += formattedPrice
+
+    return {
+      item_id: item.productId,
+      item_brand: item.brand,
+      item_name: productName,
+      item_variant: item.skuId,
+      quantity: item.quantity,
+      price: formattedPrice,
+      ...getCategoriesWithHierarchy([item.category]),
+    }
+  })
+
+  return { items, totalValue }
 }
 
 export function getPurchaseItems(orderProducts: ProductOrder[]) {

--- a/react/typings/events.d.ts
+++ b/react/typings/events.d.ts
@@ -17,6 +17,7 @@ export interface PixelMessage extends MessageEvent {
     | CartData
     | PromoViewData
     | PromotionClickData
+    | AddPaymentInfoData
 }
 
 export interface EventData {
@@ -162,6 +163,14 @@ export interface PromotionClickData extends EventData {
   event: 'promotionClick'
   eventType: 'vtex:promotionClick'
   promotions: Promotion[]
+}
+
+export interface AddPaymentInfoData extends EventData {
+  event: 'addPaymentInfo'
+  eventType: 'vtex:addPaymentInfo'
+  payment: PaymentType
+  items: CartItem[]
+  currency: string
 }
 
 type PromotionProduct = Pick<ProductSummary, 'productId' | 'productName'>


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR intends to add the `add_payment_info` GA4 event to be sent when `vtex:addPaymentInfo` is received.

[`add_payment_info` event](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?hl=en&client_type=gtag#add_payment_info)|
-|
![Captura de Tela 2023-03-01 às 17 35 34](https://user-images.githubusercontent.com/36740164/222259265-30db64dc-fb01-484c-a190-fb980e4ca44d.png)



#### How should this be manually tested?

- In your local environment, inside the `google-tag-manager` app repository, go to the branch `ffeat/ga4-new-add-payment-info-event`;
- Login in your preferred account and workspace;
- Link the app;
- Go to the Admin and access the App Store. Look for the Google Tag Manager app and access the `Settings`;
- Check the `Merge Universal Analytics and Google Analytics 4 Events` option;
- Access the store and perform add an item to the cart;
- Check the `dataLayer` object (just type `dataLayer` in the console and press enter). The event data should be in the list.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
