### PR TITLE
Feat/ga4 new begin checkout event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support for sending GA4 [`view_promotion`](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#view_promotion) when `vtex:promoView` is received.
 - Support for sending GA4 [`select_promotion`](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#select_promotion) when `vtex:promotionClick` is received.
 - Support for sending GA4 [`add_payment_info`](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#add_payment_info) when `vtex:addPaymentInfo` is received.
+- Support for sending GA4 [`begin_checkout`](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#begin_checkout) when `vtex:beginCheckout` is received.
 
 ## [3.4.0] - 2023-02-15
 

--- a/react/__mocks__/beginCheckout.ts
+++ b/react/__mocks__/beginCheckout.ts
@@ -1,0 +1,28 @@
+const cartItem1 = {
+  productId: '200000202',
+  skuId: '2000304',
+  brand: 'Sony',
+  name: 'Top Wood',
+  skuName: 'top_wood_200',
+  price: 197.99,
+  category: 'Home & Decor',
+  quantity: 1,
+}
+
+const cartItem2 = {
+  productId: '200000203',
+  skuId: '2000305',
+  brand: 'Sony',
+  name: 'Top Wood 2',
+  skuName: 'top_wood_300',
+  price: 150.9,
+  category: 'Home & Decor/Tables',
+  quantity: 1,
+}
+
+export const beginCheckoutMock = {
+  eventName: 'vtex:beginCheckout',
+  event: 'beginCheckout',
+  items: [cartItem1, cartItem2],
+  currency: 'USD',
+}

--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -13,6 +13,7 @@ import {
 } from '../typings/events'
 import { creditCardPaymentInfoMock } from '../__mocks__/addPaymentInfo'
 import shouldSendGA4Events from '../modules/utils/shouldSendGA4Events'
+import { beginCheckoutMock } from '../__mocks__/beginCheckout'
 
 jest.mock('../modules/utils/shouldSendGA4Events')
 
@@ -559,6 +560,44 @@ describe('GA4 events', () => {
               item_category: 'Home & Decor',
               quantity: 1,
               price: 197.99,
+            },
+          ],
+        },
+      })
+    })
+  })
+
+  describe('begin_checkout', () => {
+    it('sends an event when a user access the checkout page', () => {
+      const data = beginCheckoutMock
+
+      const message = new MessageEvent('message', { data })
+
+      handleEvents(message)
+
+      expect(mockedUpdate).toHaveBeenCalledWith('begin_checkout', {
+        ecommerce: {
+          currency: 'USD',
+          value: 348.89,
+          items: [
+            {
+              item_id: '200000202',
+              item_brand: 'Sony',
+              item_name: 'Top Wood',
+              item_variant: '2000304',
+              item_category: 'Home & Decor',
+              quantity: 1,
+              price: 197.99,
+            },
+            {
+              item_id: '200000203',
+              item_brand: 'Sony',
+              item_name: 'Top Wood 2',
+              item_variant: '2000305',
+              item_category: 'Home & Decor',
+              item_category2: 'Tables',
+              quantity: 1,
+              price: 150.9,
             },
           ],
         },

--- a/react/modules/enhancedEcommerceEvents.ts
+++ b/react/modules/enhancedEcommerceEvents.ts
@@ -25,6 +25,7 @@ import {
   addToCart,
   removeFromCart,
   addPaymentInfo,
+  beginCheckout,
 } from './gaEvents'
 import {
   getCategory,
@@ -330,6 +331,12 @@ export async function sendEnhancedEcommerceEvents(e: PixelMessage) {
 
     case 'vtex:addPaymentInfo': {
       addPaymentInfo(e.data)
+
+      break
+    }
+
+    case 'vtex:beginCheckout': {
+      beginCheckout(e.data)
 
       break
     }

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -7,6 +7,7 @@ import {
   ProductClickData,
   ProductViewData,
   ProductImpressionData,
+  BeginCheckoutData,
 } from '../typings/events'
 import updateEcommerce from './updateEcommerce'
 import {
@@ -236,6 +237,22 @@ export function addPaymentInfo(eventData: AddPaymentInfoData) {
     currency,
     value: formattedValue,
     payment_type: group,
+    items,
+  }
+
+  updateEcommerce(eventName, { ecommerce: data })
+}
+
+export function beginCheckout(eventData: BeginCheckoutData) {
+  const eventName = 'begin_checkout'
+
+  const { currency, items: eventDataItems } = eventData
+
+  const { items, totalValue } = formatCartItemsAndValue(eventDataItems)
+
+  const data = {
+    currency,
+    value: totalValue,
     items,
   }
 

--- a/react/typings/events.d.ts
+++ b/react/typings/events.d.ts
@@ -174,6 +174,13 @@ export interface AddPaymentInfoData extends EventData {
   currency: string
 }
 
+export interface BeginCheckoutData extends EventData {
+  event: 'beginCheckout'
+  eventType: 'vtex:beginCheckout'
+  items: CartItem[]
+  currency: string
+}
+
 type PromotionProduct = Pick<ProductSummary, 'productId' | 'productName'>
 
 interface Promotion {


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR intends to add the `begin_checkout` GA4 event to be sent when `vtex:beginCheckout` is received.

[`begin_checkout` event](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?hl=en&client_type=gtag#begin_checkout)|
-|
<img width="905" alt="Captura de Tela 2023-03-06 às 20 51 54" src="https://user-images.githubusercontent.com/36740164/223283039-0e6d4d74-1012-4fa7-8f6b-77a5970af54b.png">



#### How should this be manually tested?

- In your local environment, inside the `google-tag-manager` app repository, go to the branch `feat/ga4-new-begin-checkout-event`;
- Login in your preferred account and workspace;
- Link the app;
- Go to the Admin and access the App Store. Look for the Google Tag Manager app and access the `Settings`;
- Check the `Merge Universal Analytics and Google Analytics 4 Events` option;
- Access the store and perform add an item to the cart;
- Check the `dataLayer` object (just type `dataLayer` in the console and press enter). The event data should be in the list.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
