### PR TITLE
Feat/ga4 new view cart event

### DIFF
--- a/react/__mocks__/viewCart.ts
+++ b/react/__mocks__/viewCart.ts
@@ -1,0 +1,35 @@
+const cartItem1 = {
+  productId: '200000202',
+  skuId: '2000304',
+  brand: 'Sony',
+  name: 'Top Wood',
+  skuName: 'top_wood_200',
+  price: 197.99,
+  category: 'Home & Decor',
+  quantity: 1,
+}
+
+const cartItem2 = {
+  productId: '200000203',
+  skuId: '2000305',
+  brand: 'Sony',
+  name: 'Top Wood 2',
+  skuName: 'top_wood_300',
+  price: 150.9,
+  category: 'Home & Decor/Tables',
+  quantity: 1,
+}
+
+export const viewCartWithItemsMock = {
+  eventName: 'vtex:viewCart',
+  event: 'viewCart',
+  items: [cartItem1, cartItem2],
+  currency: 'USD',
+}
+
+export const viewCartWithNoItemsMock = {
+  eventName: 'vtex:viewCart',
+  event: 'viewCart',
+  items: [],
+  currency: 'USD',
+}

--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -14,6 +14,10 @@ import {
 import { creditCardPaymentInfoMock } from '../__mocks__/addPaymentInfo'
 import shouldSendGA4Events from '../modules/utils/shouldSendGA4Events'
 import { beginCheckoutMock } from '../__mocks__/beginCheckout'
+import {
+  viewCartWithItemsMock,
+  viewCartWithNoItemsMock,
+} from '../__mocks__/viewCart'
 
 jest.mock('../modules/utils/shouldSendGA4Events')
 
@@ -600,6 +604,58 @@ describe('GA4 events', () => {
               price: 150.9,
             },
           ],
+        },
+      })
+    })
+  })
+  describe('view_cart', () => {
+    it('sends an event when a user opens the cart with items', () => {
+      const data = viewCartWithItemsMock
+
+      const message = new MessageEvent('message', { data })
+
+      handleEvents(message)
+
+      expect(mockedUpdate).toHaveBeenCalledWith('view_cart', {
+        ecommerce: {
+          currency: 'USD',
+          value: 348.89,
+          items: [
+            {
+              item_id: '200000202',
+              item_brand: 'Sony',
+              item_name: 'Top Wood',
+              item_variant: '2000304',
+              item_category: 'Home & Decor',
+              quantity: 1,
+              price: 197.99,
+            },
+            {
+              item_id: '200000203',
+              item_brand: 'Sony',
+              item_name: 'Top Wood 2',
+              item_variant: '2000305',
+              item_category: 'Home & Decor',
+              item_category2: 'Tables',
+              quantity: 1,
+              price: 150.9,
+            },
+          ],
+        },
+      })
+    })
+    it('sends an event when a user opens the cart with no items', () => {
+      const data = viewCartWithNoItemsMock
+
+      const message = new MessageEvent('message', { data })
+
+      handleEvents(message)
+
+      expect(mockedUpdate).toHaveBeenCalledWith('view_cart', {
+        ecommerce: {
+          currency: 'USD',
+          value: 0.0,
+          items: [],
         },
       })
     })

--- a/react/modules/enhancedEcommerceEvents.ts
+++ b/react/modules/enhancedEcommerceEvents.ts
@@ -26,6 +26,7 @@ import {
   removeFromCart,
   addPaymentInfo,
   beginCheckout,
+  viewCart,
 } from './gaEvents'
 import {
   getCategory,
@@ -337,6 +338,12 @@ export async function sendEnhancedEcommerceEvents(e: PixelMessage) {
 
     case 'vtex:beginCheckout': {
       beginCheckout(e.data)
+
+      break
+    }
+
+    case 'vtex:viewCart': {
+      viewCart(e.data)
 
       break
     }

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -8,6 +8,7 @@ import {
   ProductViewData,
   ProductImpressionData,
   BeginCheckoutData,
+  ViewCartData,
 } from '../typings/events'
 import updateEcommerce from './updateEcommerce'
 import {
@@ -245,6 +246,22 @@ export function addPaymentInfo(eventData: AddPaymentInfoData) {
 
 export function beginCheckout(eventData: BeginCheckoutData) {
   const eventName = 'begin_checkout'
+
+  const { currency, items: eventDataItems } = eventData
+
+  const { items, totalValue } = formatCartItemsAndValue(eventDataItems)
+
+  const data = {
+    currency,
+    value: totalValue,
+    items,
+  }
+
+  updateEcommerce(eventName, { ecommerce: data })
+}
+
+export function viewCart(eventData: ViewCartData) {
+  const eventName = 'view_cart'
 
   const { currency, items: eventDataItems } = eventData
 

--- a/react/modules/utils.ts
+++ b/react/modules/utils.ts
@@ -182,6 +182,9 @@ function formatPurchaseProduct(product: ProductOrder) {
 
 export function formatCartItemsAndValue(cartItems: CartItem[]) {
   let totalValue = 0.0
+
+  if (!cartItems.length) return { items: [], totalValue }
+
   const items = cartItems.map((item: CartItem) => {
     const productName = getProductNameWithoutVariant(item.name, item.skuName)
     const formattedPrice =

--- a/react/typings/events.d.ts
+++ b/react/typings/events.d.ts
@@ -181,6 +181,13 @@ export interface BeginCheckoutData extends EventData {
   currency: string
 }
 
+export interface ViewCartData extends EventData {
+  event: 'viewCart'
+  eventType: 'vtex:viewCart'
+  items: CartItem[]
+  currency: string
+}
+
 type PromotionProduct = Pick<ProductSummary, 'productId' | 'productName'>
 
 interface Promotion {


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR intends to add the `view_cart` GA4 event to be sent when `vtex:viewCart` is received.

[`view_cart` event](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?hl=en&client_type=gtag#view_cart)|
-|
<img width="881" alt="Captura de Tela 2023-03-08 às 11 26 58" src="https://user-images.githubusercontent.com/36740164/223738946-c5315e32-6ac9-4041-a63b-cdfcd063fd7c.png">


#### How should this be manually tested?

- In your local environment, inside the `google-tag-manager` app repository, go to the branch `feat/ga4-new-view-cart-event`;
- Login in your preferred account and workspace;
- Link the app;
- Go to the Admin and access the App Store. Look for the Google Tag Manager app and access the `Settings`;
- Check the `Merge Universal Analytics and Google Analytics 4 Events` option;
- Access the store and perform add an item to the cart;
- Check the `dataLayer` object (just type `dataLayer` in the console and press enter). The event data should be in the list.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
