### PR TITLE
Feat/ga4 new add to wishlist event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support for sending GA4 [`add_payment_info`](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#add_payment_info) when `vtex:addPaymentInfo` is received.
 - Support for sending GA4 [`begin_checkout`](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#begin_checkout) when `vtex:beginCheckout` is received.
 - Support for sending GA4 [`view_cart`](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#view_cart) when `vtex:beginCheckout` is received.
+- Support for sending GA4 [`add_to_wishlist`](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#add_to_wishlist) when `vtex:addToWishlist` is received.
 
 ## [3.4.0] - 2023-02-15
 

--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -660,4 +660,33 @@ describe('GA4 events', () => {
       })
     })
   })
+
+  describe('add_to_wishlist', () => {
+    it('sends an event when the user add a product to wishlist', () => {
+      const message = new MessageEvent('message', { data: productDetails })
+
+      handleEvents(message)
+
+      expect(mockedUpdate).toHaveBeenCalledWith('view_item', {
+        ecommerce: {
+          currency: 'USD',
+          value: 1540.99,
+          items: [
+            {
+              item_id: '16',
+              item_name: 'Classic Shoes Top',
+              item_list_name: 'List of products',
+              item_brand: 'Mizuno',
+              item_variant: '35',
+              price: 1540.99,
+              quantity: 2000000,
+              discount: 0,
+              item_category: 'Apparel & Accessories',
+              item_category2: 'Shoes',
+            },
+          ],
+        },
+      })
+    })
+  })
 })

--- a/react/modules/enhancedEcommerceEvents.ts
+++ b/react/modules/enhancedEcommerceEvents.ts
@@ -27,6 +27,7 @@ import {
   addPaymentInfo,
   beginCheckout,
   viewCart,
+  addToWishlist,
 } from './gaEvents'
 import {
   getCategory,
@@ -344,6 +345,12 @@ export async function sendEnhancedEcommerceEvents(e: PixelMessage) {
 
     case 'vtex:viewCart': {
       viewCart(e.data)
+
+      break
+    }
+
+    case 'vtex:addToWishlist': {
+      addToWishlist(e.data)
 
       break
     }

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -9,6 +9,7 @@ import {
   ProductImpressionData,
   BeginCheckoutData,
   ViewCartData,
+  AddToWishlistData,
 } from '../typings/events'
 import updateEcommerce from './updateEcommerce'
 import {
@@ -271,6 +272,42 @@ export function viewCart(eventData: ViewCartData) {
     currency,
     value: totalValue,
     items,
+  }
+
+  updateEcommerce(eventName, { ecommerce: data })
+}
+
+export function addToWishlist(eventData: AddToWishlistData) {
+  const eventName = 'add_to_wishlist'
+
+  const { currency, product, list } = eventData
+
+  const { selectedSku, productName, productId, categories, brand } = product
+
+  const { itemId: variant } = selectedSku
+
+  const seller = getSeller(selectedSku.sellers)
+  const value = getPrice(seller)
+  const categoriesHierarchy = getCategoriesWithHierarchy(categories)
+  const discount = getDiscount(seller)
+  const quantity = getQuantity(seller)
+
+  const item = {
+    item_id: productId,
+    item_name: productName,
+    item_list_name: list,
+    item_brand: brand,
+    item_variant: variant,
+    discount,
+    quantity,
+    price: value,
+    ...categoriesHierarchy,
+  }
+
+  const data = {
+    currency,
+    value,
+    items: [item],
   }
 
   updateEcommerce(eventName, { ecommerce: data })

--- a/react/typings/events.d.ts
+++ b/react/typings/events.d.ts
@@ -171,21 +171,25 @@ export interface AddPaymentInfoData extends EventData {
   eventType: 'vtex:addPaymentInfo'
   payment: PaymentType
   items: CartItem[]
-  currency: string
 }
 
 export interface BeginCheckoutData extends EventData {
   event: 'beginCheckout'
   eventType: 'vtex:beginCheckout'
   items: CartItem[]
-  currency: string
 }
 
 export interface ViewCartData extends EventData {
   event: 'viewCart'
   eventType: 'vtex:viewCart'
   items: CartItem[]
-  currency: string
+}
+
+export interface AddToWishlistData extends EventData {
+  event: 'addToWishlist'
+  eventType: 'vtex:addToWishlist'
+  product: Product
+  list: string
 }
 
 type PromotionProduct = Pick<ProductSummary, 'productId' | 'productName'>


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR intends to add the `add_to_wishlist` GA4 event to be sent when `vtex:addToWishlist` is received.

[`add_to_wishlist` event](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?hl=en&client_type=gtag#add_to_wishlist)|
-|
<img width="914" alt="Captura de Tela 2023-03-13 às 17 23 21" src="https://user-images.githubusercontent.com/36740164/224823868-e59dfa2a-53de-4cbd-a6ad-fab6a5b8d848.png">



#### How should this be manually tested?

- In your local environment, inside the `google-tag-manager` app repository, go to the branch `feat/ga4-new-add-to-wishlist-event`;
- Login in your preferred account and workspace;
- Link the app;
- Go to the Admin and access the App Store. Look for the Google Tag Manager app and access the `Settings`;
- Check the `Merge Universal Analytics and Google Analytics 4 Events` option;
- Access the store and perform add a product to wishlist;
- Check the `dataLayer` object (just type `dataLayer` in the console and press enter). The event data should be in the list.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
