### PR TITLE
Feat/ga4 new signup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support for sending GA4 [`login`](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#login) when `vtex:login` is received.
 - Support for sending GA4 [`refund`](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#refund) when `vtex:refund` is received.
 - Support for sending GA4 [`add_to_wishlist`](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#add_to_wishlist) when `vtex:addToWishlist` is received.
+- Support for sending GA4 [`sign_up`](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#sign_up) when `vtex:signUp` is received.
 
 ## [3.4.0] - 2023-02-15
 

--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -712,4 +712,23 @@ describe('GA4 events', () => {
       })
     })
   })
+  describe('sign_up', () => {
+    it('sends an event when a user signup on store with any method', () => {
+      const data = {
+        event: 'signUp',
+        eventName: 'vtex:signUp',
+        method: 'Google',
+      }
+
+      const message = new MessageEvent('message', { data })
+
+      handleEvents(message)
+
+      expect(mockedUpdate).toHaveBeenCalledWith('sign_up', {
+        ecommerce: {
+          method: 'Google',
+        },
+      })
+    })
+  })
 })

--- a/react/modules/enhancedEcommerceEvents.ts
+++ b/react/modules/enhancedEcommerceEvents.ts
@@ -31,6 +31,7 @@ import {
   login,
   refund,
   addToWishlist,
+  signUp,
 } from './gaEvents'
 import {
   getCategory,
@@ -354,6 +355,12 @@ export async function sendEnhancedEcommerceEvents(e: PixelMessage) {
 
     case 'vtex:login': {
       login(e.data)
+
+      break
+    }
+
+    case 'vtex:signUp': {
+      signUp(e.data)
 
       break
     }

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -13,6 +13,7 @@ import {
   LoginData,
   RefundData,
   AddToWishlistData,
+  SignUpData,
 } from '../typings/events'
 import updateEcommerce from './updateEcommerce'
 import {
@@ -342,6 +343,18 @@ export function refund(eventData: RefundData) {
 
 export function login(eventData: LoginData) {
   const eventName = 'login'
+
+  const { method } = eventData
+
+  const data = {
+    method,
+  }
+
+  updateEcommerce(eventName, { ecommerce: data })
+}
+
+export function signUp(eventData: SignUpData) {
+  const eventName = 'sign_up'
 
   const { method } = eventData
 

--- a/react/typings/events.d.ts
+++ b/react/typings/events.d.ts
@@ -204,9 +204,14 @@ export interface SearchData extends EventData {
 }
 
 export interface LoginData extends EventData {
-  event: 'viewCart'
-  eventType: 'vtex:viewCart'
+  event: 'login'
+  eventType: 'vtex:login'
   method: string
+}
+
+export interface SignUpData extends LoginData, EventData {
+  event: 'signUp'
+  eventType: 'vtex:signUp'
 }
 
 type PromotionProduct = Pick<ProductSummary, 'productId' | 'productName'>

--- a/react/typings/events.d.ts
+++ b/react/typings/events.d.ts
@@ -19,6 +19,8 @@ export interface PixelMessage extends MessageEvent {
     | PromoViewData
     | PromotionClickData
     | AddPaymentInfoData
+    | SignUpData
+    | LoginData
 }
 
 export interface EventData {


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR intends to add the `sign_up` GA4 event to be sent when `vtex:signUp` is received.

[`sign_up` event](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?hl=en&client_type=gtag#sign_up)|
-|
<img width="916" alt="Captura de Tela 2023-03-16 às 16 21 19" src="https://user-images.githubusercontent.com/36740164/225730763-96f18eb6-4a82-4a9b-91a4-5b1df3d2ca74.png">


#### How should this be manually tested?

- In your local environment, inside the `google-tag-manager` app repository, go to the branch `feat/ga4-new-sign-up-event`;
- Login in your preferred account and workspace;
- Link the app;
- Go to the Admin and access the App Store. Look for the Google Tag Manager app and access the `Settings`;
- Check the `Merge Universal Analytics and Google Analytics 4 Events` option;
- Access the store and perform a signup;
- Check the `dataLayer` object (just type `dataLayer` in the console and press enter). The event data should be in the list.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
