### PR TITLE
Feat/ GA4 share event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support for sending GA4 [`refund`](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#refund) when `vtex:refund` is received.
 - Support for sending GA4 [`add_to_wishlist`](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#add_to_wishlist) when `vtex:addToWishlist` is received.
 - Support for sending GA4 [`sign_up`](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#sign_up) when `vtex:signUp` is received.
+- Support for sending GA4 [`share`](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#share) when `vtex:share` is received.
 
 ## [3.4.0] - 2023-02-15
 

--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -739,7 +739,7 @@ describe('GA4 events', () => {
         event: 'share',
         eventName: 'vtex:share',
         method: 'Facebook',
-        type: 'image',
+        contentType: 'image',
         itemId: '10',
       }
 

--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -732,4 +732,27 @@ describe('GA4 events', () => {
       })
     })
   })
+  describe('share', () => {
+    it('sends an event when a user share a product via any type', () => {
+      const data = {
+        event: 'share',
+        eventName: 'vtex:share',
+        method: 'Facebook',
+        type: 'image',
+        itemId: '10',
+      }
+
+      const message = new MessageEvent('message', { data })
+
+      handleEvents(message)
+
+      expect(mockedUpdate).toHaveBeenCalledWith('share', {
+        ecommerce: {
+          method: 'Facebook',
+          content_type: 'image',
+          item_id: '10',
+        },
+      })
+    })
+  })
 })

--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -732,6 +732,7 @@ describe('GA4 events', () => {
       })
     })
   })
+
   describe('share', () => {
     it('sends an event when a user share a product via any type', () => {
       const data = {

--- a/react/modules/enhancedEcommerceEvents.ts
+++ b/react/modules/enhancedEcommerceEvents.ts
@@ -32,6 +32,7 @@ import {
   refund,
   addToWishlist,
   signUp,
+  share,
 } from './gaEvents'
 import {
   getCategory,
@@ -379,6 +380,12 @@ export async function sendEnhancedEcommerceEvents(e: PixelMessage) {
 
     case 'vtex:search': {
       search(e.data)
+
+      break
+    }
+
+    case 'vtex:share': {
+      share(e.data)
 
       break
     }

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -14,6 +14,7 @@ import {
   RefundData,
   AddToWishlistData,
   SignUpData,
+  ShareData,
 } from '../typings/events'
 import updateEcommerce from './updateEcommerce'
 import {
@@ -372,6 +373,20 @@ export function search(eventData: SearchData) {
 
   const data = {
     search_term: term,
+  }
+
+  updateEcommerce(eventName, { ecommerce: data })
+}
+
+export function share(eventData: ShareData) {
+  const eventName = 'share'
+
+  const { method, type, itemId } = eventData
+
+  const data = {
+    method,
+    content_type: type,
+    item_id: itemId,
   }
 
   updateEcommerce(eventName, { ecommerce: data })

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -381,11 +381,11 @@ export function search(eventData: SearchData) {
 export function share(eventData: ShareData) {
   const eventName = 'share'
 
-  const { method, type, itemId } = eventData
+  const { method, contentType, itemId } = eventData
 
   const data = {
     method,
-    content_type: type,
+    content_type: contentType,
     item_id: itemId,
   }
 

--- a/react/typings/events.d.ts
+++ b/react/typings/events.d.ts
@@ -21,6 +21,7 @@ export interface PixelMessage extends MessageEvent {
     | AddPaymentInfoData
     | SignUpData
     | LoginData
+    | ShareData
 }
 
 export interface EventData {
@@ -203,6 +204,14 @@ export interface SearchData extends EventData {
   event: 'search'
   eventType: 'vtex:search'
   term: string
+}
+
+export interface ShareData extends EventData {
+  event: 'share'
+  eventType: 'vtex:share'
+  method: string
+  type: string
+  itemId: string
 }
 
 export interface LoginData extends EventData {

--- a/react/typings/events.d.ts
+++ b/react/typings/events.d.ts
@@ -210,7 +210,7 @@ export interface ShareData extends EventData {
   event: 'share'
   eventType: 'vtex:share'
   method: string
-  type: string
+  contentType: string
   itemId: string
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR intends to add the `share` GA4 event to be sent when `vtex:share` is received.

[`share` event](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?hl=en&client_type=gtag#share)|
-|
<img width="910" alt="Captura de Tela 2023-03-17 às 18 01 44" src="https://user-images.githubusercontent.com/36740164/226047047-d419d910-53bb-4030-aa89-21be8bbe3b23.png">




#### How should this be manually tested?

- In your local environment, inside the `google-tag-manager` app repository, go to the branch `feat/ga4-new-share-event`;
- Login in your preferred account and workspace;
- Link the app;
- Go to the Admin and access the App Store. Look for the Google Tag Manager app and access the `Settings`;
- Check the `Merge Universal Analytics and Google Analytics 4 Events` option;
- Access the store and go to a product page, and perform a share via any social network;
- Check the `dataLayer` object (just type `dataLayer` in the console and press enter). The event data should be in the list.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
