### PR TITLE
Fix/ add categories new format, and price division to `view_cart`

### DIFF
--- a/react/__mocks__/viewCart.ts
+++ b/react/__mocks__/viewCart.ts
@@ -4,7 +4,7 @@ const cartItem1 = {
   brand: 'Sony',
   name: 'Top Wood',
   skuName: 'top_wood_200',
-  price: 197.99,
+  price: 19799,
   category: 'Home & Decor',
   quantity: 2,
 }
@@ -15,7 +15,7 @@ const cartItem2 = {
   brand: 'Sony',
   name: 'Top Wood 2',
   skuName: 'top_wood_300',
-  price: 150.9,
+  price: 15090,
   category: 'Home & Decor/Tables',
   quantity: 1,
 }

--- a/react/__mocks__/viewCart.ts
+++ b/react/__mocks__/viewCart.ts
@@ -1,22 +1,33 @@
 const cartItem1 = {
   productId: '200000202',
   skuId: '2000304',
-  brand: 'Sony',
+  additionalInfo: {
+    brandName: 'Sony',
+  },
   name: 'Top Wood',
   skuName: 'top_wood_200',
   price: 19799,
-  category: 'Home & Decor',
+  productCategories: {
+    '25': 'Home & Decor',
+  },
+  productCategoryIds: '/25/',
   quantity: 2,
 }
 
 const cartItem2 = {
   productId: '200000203',
   skuId: '2000305',
-  brand: 'Sony',
+  additionalInfo: {
+    brandName: 'Sony',
+  },
   name: 'Top Wood 2',
   skuName: 'top_wood_300',
   price: 15090,
-  category: 'Home & Decor/Tables',
+  productCategories: {
+    '25': 'Home & Decor',
+    '32': 'Tables',
+  },
+  productCategoryIds: '/25/32/',
   quantity: 1,
 }
 

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -289,7 +289,9 @@ export function viewCart(eventData: ViewCartData) {
 
   const { currency, items: eventDataItems } = eventData
 
-  const { items, totalValue } = formatCartItemsAndValue(eventDataItems, true)
+  const { items, totalValue } = formatCartItemsAndValue(eventDataItems, {
+    dividePrice: true,
+  })
 
   const data = {
     currency,

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -289,7 +289,7 @@ export function viewCart(eventData: ViewCartData) {
 
   const { currency, items: eventDataItems } = eventData
 
-  const { items, totalValue } = formatCartItemsAndValue(eventDataItems)
+  const { items, totalValue } = formatCartItemsAndValue(eventDataItems, true)
 
   const data = {
     currency,

--- a/react/typings/events.d.ts
+++ b/react/typings/events.d.ts
@@ -252,6 +252,7 @@ interface CartItemAdditionalInfo {
 interface CartItem {
   id: string
   productCategories: Record<string, string> | null
+  productCategoryIds?: string
   additionalInfo: CartItemAdditionalInfo | null
   brand: string
   ean: string


### PR DESCRIPTION
#### What is the purpose of this pull request?

Correct the object format on the new `view_cart` event triggered on [mincart app](https://github.com/vtex-apps/minicart/blob/feat/add-ga4-viewcart-event/react/Minicart.tsx#L68) 

#### What problem is this solving?

The event sends different object attributes for categories and price format, so the price was being send as an integer and the categories was not being sended 

#### How should this be manually tested?
* Go to this [branch of minicart app](https://github.com/vtex-apps/minicart/tree/feat/add-ga4-viewcart-event)
* Link minicart app on store
* Switch to [branch with fixes on gtm](https://github.com/vtex-apps/google-tag-manager/tree/fix/ga4-viewcart-event-format) and link on store
* Open the minicart and check on `window.dataLayer` if the item has the correct attributes

#### Screenshots or example usage
<img width="1431" alt="Captura de Tela 2023-04-05 às 18 23 09" src="https://user-images.githubusercontent.com/36740164/230214585-fd23a4ed-2d62-49a3-be45-2b6a6cf3aea5.png">

#### Types of changes

* [X] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
