### PR TITLE
Fix minor error in the `add_to_wishlist` test

### DIFF
--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -682,6 +682,8 @@ describe('GA4 events', () => {
     it('sends an event when the user add a product to wishlist', () => {
       const message = new MessageEvent('message', { data: productDetails })
 
+      message.data.eventName = 'vtex:addToWishlist'
+
       handleEvents(message)
 
       expect(mockedUpdate).toHaveBeenCalledWith('add_to_wishlist', {

--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -684,7 +684,7 @@ describe('GA4 events', () => {
 
       handleEvents(message)
 
-      expect(mockedUpdate).toHaveBeenCalledWith('view_item', {
+      expect(mockedUpdate).toHaveBeenCalledWith('add_to_wishlist', {
         ecommerce: {
           currency: 'USD',
           value: 1540.99,


### PR DESCRIPTION
The event should have been called `add_to_wishlist`, not `view_item`.