### PR TITLE
Remove unused `CartData` type from the interface `PixelMessage`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Chore
+
+- Removed the unused `CartData` type from the `PixelMessage` interface.
+
 ## [3.4.2] - 2023-04-13
 
 ### Security

--- a/react/typings/events.d.ts
+++ b/react/typings/events.d.ts
@@ -161,12 +161,14 @@ export interface CartLoadedData extends EventData {
 export interface PromoViewData extends EventData {
   event: 'promoView'
   eventType: 'vtex:promoView'
+  eventName: 'vtex:promoView'
   promotions: Promotion[]
 }
 
 export interface PromotionClickData extends EventData {
   event: 'promotionClick'
   eventType: 'vtex:promotionClick'
+  eventName: 'vtex:promoView'
   promotions: Promotion[]
 }
 

--- a/react/typings/events.d.ts
+++ b/react/typings/events.d.ts
@@ -14,7 +14,6 @@ export interface PixelMessage extends MessageEvent {
     | SearchPageInfoData
     | UserData
     | CartIdData
-    | CartData
     | PromoViewData
     | PromotionClickData
 }

--- a/react/typings/events.d.ts
+++ b/react/typings/events.d.ts
@@ -5,6 +5,7 @@ export interface PixelMessage extends MessageEvent {
     | OrderPlacedData
     | OrderPlacedTrackedData
     | PageViewData
+    | LegacyProductViewData
     | ProductImpressionData
     | AddToCartData
     | RemoveToCartData
@@ -30,6 +31,12 @@ export interface PageInfoData extends EventData {
   accountName: string
   pageTitle: string
   pageUrl: string
+}
+
+export interface LegacyProductViewData extends EventData {
+  event: 'pageInfo'
+  eventName: 'vtex:pageInfo'
+  eventType: 'productView'
 }
 
 export interface UserData extends PageInfoData {

--- a/react/typings/events.d.ts
+++ b/react/typings/events.d.ts
@@ -15,6 +15,7 @@ export interface PixelMessage extends MessageEvent {
     | SearchPageInfoData
     | UserData
     | CartIdData
+    | CartLoadedData
     | PromoViewData
     | PromotionClickData
 }

--- a/react/typings/events.d.ts
+++ b/react/typings/events.d.ts
@@ -169,7 +169,7 @@ export interface PromoViewData extends EventData {
 export interface PromotionClickData extends EventData {
   event: 'promotionClick'
   eventType: 'vtex:promotionClick'
-  eventName: 'vtex:promoView'
+  eventName: 'vtex:promotionClick'
   promotions: Promotion[]
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

This `CartData` type isn't defined anywhere in the project, so it's useless.

Originally added [here](https://github.com/vtex-apps/google-tag-manager/pull/38/files#diff-791619406f30fb7292cdecb798d2a840d54a926399fdcd740a7706dbe852c9a6), it was later [renamed](https://github.com/vtex-apps/google-tag-manager/pull/40/files#diff-791619406f30fb7292cdecb798d2a840d54a926399fdcd740a7706dbe852c9a6) to `CartLoadedData` but `CartData` [remained](https://github.com/vtex-apps/google-tag-manager/blob/f785e969c4b947a8c699598c46bdefde3cca79a2/react/typings/events.d.ts#L17) in the `PixelMessage` list.

Removing it surfaced a lot of [type errors](https://master--vtex.myvtex.com/admin/builder-log/build-log-viewer/26700d9aa5734768bb4491399ca38463) because since it was not defined, it was working as the `any` type, preventing any type enforcement.

#### Screenshots or example usage

<img width="479" alt="CleanShot 2023-04-25 at 16 32 45@2x" src="https://user-images.githubusercontent.com/381395/234383504-ad76b220-37e8-4681-b85a-cb5a3c01652a.png">

Before|After
-|-
![tsc-before](https://user-images.githubusercontent.com/381395/234418283-3bd748d3-26a9-401e-ac56-0caf49e77f70.png)|![tsc-after](https://user-images.githubusercontent.com/381395/234418290-ec627ce7-7054-4aa0-ac1b-26feab9906ab.png)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.




