### PR TITLE
Fix many hidden type errors

### DIFF
--- a/react/modules/enhancedEcommerceEvents.ts
+++ b/react/modules/enhancedEcommerceEvents.ts
@@ -4,15 +4,7 @@ import {
   ProductOrder,
   Impression,
   CartItem,
-  AddToCartData,
-  RemoveFromCartData,
-  ProductViewData,
-  ProductClickData,
   ProductViewReferenceId,
-  PromoViewData,
-  OrderPlacedData,
-  ProductImpressionData,
-  CartLoadedData,
 } from '../typings/events'
 import { AnalyticsEcommerceProduct } from '../typings/gtm'
 import {
@@ -54,7 +46,7 @@ export async function sendEnhancedEcommerceEvents(e: PixelMessage) {
         productName,
         brand,
         categories,
-      } = (e.data as ProductViewData).product
+      } = e.data.product
 
       const productAvailableQuantity = getSeller(selectedSku.sellers)
         .commertialOffer.AvailableQuantity
@@ -110,7 +102,7 @@ export async function sendEnhancedEcommerceEvents(e: PixelMessage) {
     }
 
     case 'vtex:productClick': {
-      const { product, position } = e.data as ProductClickData
+      const { product, position } = e.data
       const {
         productName,
         brand,
@@ -162,7 +154,7 @@ export async function sendEnhancedEcommerceEvents(e: PixelMessage) {
     }
 
     case 'vtex:addToCart': {
-      const { items } = e.data as AddToCartData
+      const { items } = e.data
 
       const data = {
         ecommerce: {
@@ -195,7 +187,7 @@ export async function sendEnhancedEcommerceEvents(e: PixelMessage) {
     }
 
     case 'vtex:removeFromCart': {
-      const { items } = e.data as RemoveFromCartData
+      const { items } = e.data
 
       const data = {
         ecommerce: {
@@ -228,7 +220,7 @@ export async function sendEnhancedEcommerceEvents(e: PixelMessage) {
     }
 
     case 'vtex:orderPlaced': {
-      const order = e.data as OrderPlacedData
+      const order = e.data
 
       const ecommerce = {
         purchase: {
@@ -261,7 +253,7 @@ export async function sendEnhancedEcommerceEvents(e: PixelMessage) {
     }
 
     case 'vtex:productImpression': {
-      const { currency, list, impressions } = e.data as ProductImpressionData
+      const { currency, list, impressions } = e.data
 
       const parsedImpressions = (impressions || []).map(
         getProductImpressionObjectData(list)
@@ -282,7 +274,7 @@ export async function sendEnhancedEcommerceEvents(e: PixelMessage) {
     }
 
     case 'vtex:cartLoaded': {
-      const { orderForm } = e.data as CartLoadedData
+      const { orderForm } = e.data
 
       const data = {
         event: 'checkout',
@@ -302,7 +294,7 @@ export async function sendEnhancedEcommerceEvents(e: PixelMessage) {
     }
 
     case 'vtex:promoView': {
-      const { promotions } = e.data as PromoViewData
+      const { promotions } = e.data
 
       const data = {
         event: 'promoView',
@@ -320,7 +312,7 @@ export async function sendEnhancedEcommerceEvents(e: PixelMessage) {
     }
 
     case 'vtex:promotionClick': {
-      const { promotions } = e.data as PromoViewData
+      const { promotions } = e.data
 
       const data = {
         event: 'promotionClick',

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -16,6 +16,7 @@ import {
   AddToWishlistData,
   SignUpData,
   ShareData,
+  PromotionClickData,
 } from '../typings/events'
 import updateEcommerce from './updateEcommerce'
 import {
@@ -124,7 +125,7 @@ export function selectItem(eventData: ProductClickData) {
   updateEcommerce(eventName, { ecommerce: data })
 }
 
-export function selectPromotion(eventData: PromoViewData) {
+export function selectPromotion(eventData: PromotionClickData) {
   if (!shouldSendGA4Events()) return
 
   const eventName = 'select_promotion'

--- a/react/typings/events.d.ts
+++ b/react/typings/events.d.ts
@@ -5,6 +5,7 @@ export interface PixelMessage extends MessageEvent {
     | OrderPlacedData
     | OrderPlacedTrackedData
     | PageViewData
+    | LegacyProductViewData
     | ProductImpressionData
     | AddToCartData
     | RemoveFromCartData
@@ -14,7 +15,6 @@ export interface PixelMessage extends MessageEvent {
     | SearchPageInfoData
     | UserData
     | CartIdData
-    | CartData
     | CartLoadedData
     | PromoViewData
     | PromotionClickData
@@ -23,6 +23,11 @@ export interface PixelMessage extends MessageEvent {
     | SignUpData
     | LoginData
     | ShareData
+    | BeginCheckoutData
+    | ViewCartData
+    | RefundData
+    | AddToWishlistData
+    | SearchData
 }
 
 export interface EventData {
@@ -37,6 +42,12 @@ export interface PageInfoData extends EventData {
   accountName: string
   pageTitle: string
   pageUrl: string
+}
+
+export interface LegacyProductViewData extends EventData {
+  event: 'pageInfo'
+  eventName: 'vtex:pageInfo'
+  eventType: 'productView'
 }
 
 export interface UserData extends PageInfoData {
@@ -161,18 +172,21 @@ export interface CartLoadedData extends EventData {
 export interface PromoViewData extends EventData {
   event: 'promoView'
   eventType: 'vtex:promoView'
+  eventName: 'vtex:promoView'
   promotions: Promotion[]
 }
 
 export interface PromotionClickData extends EventData {
   event: 'promotionClick'
   eventType: 'vtex:promotionClick'
+  eventName: 'vtex:promotionClick'
   promotions: Promotion[]
 }
 
 export interface AddPaymentInfoData extends EventData {
   event: 'addPaymentInfo'
   eventType: 'vtex:addPaymentInfo'
+  eventName: 'vtex:addPaymentInfo'
   payment: PaymentType
   items: CartItem[]
 }
@@ -180,12 +194,14 @@ export interface AddPaymentInfoData extends EventData {
 export interface BeginCheckoutData extends EventData {
   event: 'beginCheckout'
   eventType: 'vtex:beginCheckout'
+  eventName: 'vtex:beginCheckout'
   items: CartItem[]
 }
 
 export interface AddShippingInfoData extends EventData {
   event: 'addShippingInfo'
   eventType: 'vtex:addShippingInfo'
+  eventName: 'vtex:addShippingInfo'
   items: CartItem[]
   shippingTier: string
   value: number
@@ -194,12 +210,14 @@ export interface AddShippingInfoData extends EventData {
 export interface ViewCartData extends EventData {
   event: 'viewCart'
   eventType: 'vtex:viewCart'
+  eventName: 'vtex:viewCart'
   items: CartItem[]
 }
 
 export interface AddToWishlistData extends EventData {
   event: 'addToWishlist'
   eventType: 'vtex:addToWishlist'
+  eventName: 'vtex:addToWishlist'
   product: Product
   list: string
 }
@@ -207,17 +225,20 @@ export interface AddToWishlistData extends EventData {
 export interface RefundData extends Order, EventData {
   event: 'refund'
   eventType: 'vtex:refund'
+  eventName: 'vtex:refund'
 }
 
 export interface SearchData extends EventData {
   event: 'search'
   eventType: 'vtex:search'
+  eventName: 'vtex:search'
   term: string
 }
 
 export interface ShareData extends EventData {
   event: 'share'
   eventType: 'vtex:share'
+  eventName: 'vtex:share'
   method: string
   contentType: string
   itemId: string
@@ -226,12 +247,14 @@ export interface ShareData extends EventData {
 export interface LoginData extends EventData {
   event: 'login'
   eventType: 'vtex:login'
+  eventName: 'vtex:login'
   method: string
 }
 
 export interface SignUpData extends LoginData, EventData {
   event: 'signUp'
   eventType: 'vtex:signUp'
+  eventName: 'vtex:signUp'
 }
 
 type PromotionProduct = Pick<ProductSummary, 'productId' | 'productName'>


### PR DESCRIPTION
#### What is the purpose of this pull request?

I noticed the `CartData` type inside the interface `PixelMessage` wasn't defined anywhere in the project and decided to remove it.

<img width="479" alt="CleanShot 2023-04-25 at 16 32 45@2x" src="https://user-images.githubusercontent.com/381395/234383504-ad76b220-37e8-4681-b85a-cb5a3c01652a.png">

Because it was unresolved, it took the type of `any`. This caused our event types to lose effectiveness as `any` was too wide. It surfaced as many as 31 type errors that we weren't handling! This PR addresses these errors.

##### History on `CartData`

Originally added [here](https://github.com/vtex-apps/google-tag-manager/pull/38/files#diff-791619406f30fb7292cdecb798d2a840d54a926399fdcd740a7706dbe852c9a6), it was later [renamed](https://github.com/vtex-apps/google-tag-manager/pull/40/files#diff-791619406f30fb7292cdecb798d2a840d54a926399fdcd740a7706dbe852c9a6) to `CartLoadedData` but `CartData` [remained](https://github.com/vtex-apps/google-tag-manager/blob/f785e969c4b947a8c699598c46bdefde3cca79a2/react/typings/events.d.ts#L17) in the `PixelMessage` list, when it should have been removed.

#### Screenshots or example usage

Before|After
-|-
![tsc-before2](https://user-images.githubusercontent.com/381395/234426791-cefd1007-3c0f-406e-92e5-0df510e5c67d.png)|![tsc-after](https://user-images.githubusercontent.com/381395/234418290-ec627ce7-7054-4aa0-ac1b-26feab9906ab.png)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.




