### PR TITLE
Fixing category hierarchy to purchase event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Fix `item_category` hierarchy on event `purchase`
+
 ## [3.5.1] - 2023-05-10
 ### Fixed
 - Fix attributes received from `eventData` on event `vtex:addToWishlist` extracting `items.product` ans using `sku` instead `selectedSku`

--- a/react/modules/utils.ts
+++ b/react/modules/utils.ts
@@ -205,7 +205,7 @@ function formatPurchaseProduct(product: ProductOrder) {
     sku,
     price,
     quantity,
-    category,
+    categoryTree,
     productRefId,
     skuRefId,
   } = product
@@ -219,7 +219,7 @@ function formatPurchaseProduct(product: ProductOrder) {
     item_variant: sku,
     price,
     quantity,
-    ...getCategoriesWithHierarchy([category]),
+    ...getCategoriesWithHierarchy([categoryTree.join('/')]),
     ...customDimensions({
       productReference: productRefId,
       skuReference: skuRefId,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix purchase GA4 event

#### What problem is this solving?
The purchase event has a wrong format to categories hierarchy. Actually there is just one level to item_category and correct is to have all category tree splitted by level, like item_category, item_category2, item_category3... 

#### How should this be manually tested?
Generate a purchase event and check the format of item_category

#### Screenshots or example usage
![Captura de Tela 2023-08-29 às 16 40 06](https://github.com/vtex-apps/google-tag-manager/assets/88559746/5650fe7d-d42c-4f73-8930-d8949b3cd4fa)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
