### PR TITLE
feat: autocomplete dataLayer events

### DIFF
--- a/react/modules/enhancedEcommerceEvents.ts
+++ b/react/modules/enhancedEcommerceEvents.ts
@@ -20,6 +20,7 @@ import {
   addShippingInfo,
   viewCart,
   search,
+  autocomplete,
   login,
   refund,
   addToWishlist,
@@ -374,6 +375,12 @@ export async function sendEnhancedEcommerceEvents(e: PixelMessage) {
 
     case 'vtex:search': {
       search(e.data)
+
+      break
+    }
+
+    case 'vtex:autocomplete': {
+      autocomplete(e.data)
 
       break
     }

--- a/react/modules/gaEvents.ts
+++ b/react/modules/gaEvents.ts
@@ -17,6 +17,7 @@ import {
   SignUpData,
   ShareData,
   PromotionClickData,
+  AutocompleteData,
 } from '../typings/events'
 import updateEcommerce from './updateEcommerce'
 import {
@@ -366,7 +367,9 @@ export function addToWishlist(eventData: AddToWishlistData) {
     ...categoriesHierarchy,
     ...customDimensions({
       productReference,
-      skuReference: sku ? sku.referenceId.Value : items.selectedItem.referenceId,
+      skuReference: sku
+        ? sku.referenceId.Value
+        : items.selectedItem.referenceId,
       skuName: sku ? sku.name : items.selectedItem.name,
       quantity,
     }),
@@ -442,6 +445,16 @@ export function search(eventData: SearchData) {
   }
 
   updateEcommerce(eventName, { ecommerce: data })
+}
+
+export function autocomplete(eventData: AutocompleteData) {
+  const { eventType } = eventData
+
+  const data = {
+    term: eventData.search.term,
+  }
+
+  updateEcommerce(eventType, { ecommerce: data })
 }
 
 export function share(eventData: ShareData) {

--- a/react/typings/events.d.ts
+++ b/react/typings/events.d.ts
@@ -28,6 +28,7 @@ export interface PixelMessage extends MessageEvent {
     | RefundData
     | AddToWishlistData
     | SearchData
+    | AutocompleteData
 }
 
 export interface EventData {
@@ -273,11 +274,22 @@ export interface RefundData extends EventData {
   }
 }
 
+export interface SearchAutocompleteData {
+  term: string
+}
+
 export interface SearchData extends EventData {
   event: 'search'
   eventType: 'vtex:search'
   eventName: 'vtex:search'
   term: string
+}
+
+export interface AutocompleteData extends EventData {
+  event: 'autocomplete'
+  eventType: string
+  eventName: 'vtex:autocomplete'
+  search: SearchAutocompleteData
 }
 
 export interface ShareData extends EventData {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Enviar eventos de dentro do autocomplete para o dataLayer.

#### What problem is this solving?

O código atual já tinha uma estrutura inicial para enviar os eventos dentro do autocomplete, porém, esses eventos não estavam sendo enviados, como:
- Clique no termo de sugestões
- Clique no termo de histórico de busca
- Clique no produto
- etc

Com os ajustes, os seguintes eventos agora são disparados:

**top_search_click**: quando um dos termos mais buscados é clicado.
**history_click**: quando um dos termos do histórico de busca é clicado.
**search_suggestion_click**: quando é clicado em algum termo de sugestão.
**see_all_products_click**: quando é clicado na opção ver todos os produtos, se houver product-summary.
**productClick**: quando é clicado sobre algum produto.

**handleAutocompleteSearch**: descontinuei, pois não estava enviando eventos **search** e acabava sobrepondo qualquer um dos eventos acima, enviando os dados vazios.

#### How should this be manually tested?

**top_search_click**: clique no input da barra de busca e em seguida clique em um dos termos mais buscados.
**history_click**:  clique no input da barra de busca e em seguida clique em dos termos que você já pesquisou e que está no histórico de busca,
**search_suggestion_click**: clique no input da barra de busca e em seguida digite algum termo. Algumas sugestões de termos irão aparecer, clique em alguma delas.
**see_all_products_click**: clique no input da barra de busca e em seguida digite algum termo. Na shelf, clique em ver todos os produtos (caso tenha). 
**productClick**: clique no input da barra de busca e em seguida digite algum termo. Na shelf, clique sobre algum produto (caso tenha).

Essa PR também tem dependências de outras PRs:
https://github.com/vtex-apps/search/pull/203
https://github.com/vtex-apps/pixel-manager/pull/39

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
